### PR TITLE
Tighten prototype addon docs and command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,44 @@ Gaps worth building:
 4. Better party coordination UX
 5. Portable profile/config sync tooling
 
+## 🗂️ Repository layout
+
+- `addons/` — prototype Windower addon scaffolds that accompany the research
+- `specs/` — short v0.1 design notes for prototype ideas
+- `docs/` — roadmap and reference links used during the landscape scan
+- catalog/index files in the repo root — generated research artifacts for analysis and filtering
+
+## 🧩 Prototype addon status
+
+`addons/TravelRouter` and `addons/SessionConductor` are intentionally early-stage prototypes.
+They are useful as:
+- implementation sketches
+- IPC/command-shape examples
+- starting points for a real addon project
+
+They are **not** presented as production-ready automation.
+Current constraints include static route data, no persistence layer, and a deliberately tiny IPC protocol.
+
+## ▶️ Trying the prototype addons
+
+Copy each addon folder into your Windower `addons/` directory, then load them in game:
+
+```text
+//lua load TravelRouter
+//lua load SessionConductor
+```
+
+Suggested smoke test:
+
+```text
+//troute list
+//troute plan jeuno
+//conductor ping
+//conductor travel jeuno
+```
+
+If you only load `SessionConductor`, the `travel` command will still broadcast, but actual route execution expects `TravelRouter` to be present on the receiving instance.
+
 ## 🧪 Prototype addons
 
 - `addons/TravelRouter` — content-aware travel route planner/executor

--- a/addons/SessionConductor/README.md
+++ b/addons/SessionConductor/README.md
@@ -2,6 +2,11 @@
 
 Multi-character session conductor addon for Windower.
 
+## Install
+- Copy `addons/SessionConductor` into your Windower `addons/` directory.
+- Load with `//lua load SessionConductor`.
+- For coordinated travel, also load `TravelRouter` on each participating instance.
+
 ## What it does
 - Sends coordinated commands across characters via IPC.
 - Can orchestrate travel runs for all connected characters.
@@ -35,3 +40,8 @@ When `travel` is used:
 ---
 
 Prototype only. Future version should add team roster, ack tracking, timeout handling, and scoped groups.
+
+## Safety / scope notes
+- `command` rebroadcasts arbitrary Windower commands to peers. Treat it as trusted-party tooling, not a hardened remote-control layer.
+- The current IPC protocol uses `|` as a delimiter, so payloads containing `|` are intentionally rejected.
+- There is no ack/timeout/roster model yet; this is still scaffolding.

--- a/addons/SessionConductor/sessionconductor.lua
+++ b/addons/SessionConductor/sessionconductor.lua
@@ -21,6 +21,20 @@ local function self_name()
     return (p and p.name) or 'unknown'
 end
 
+local function normalize_command(raw)
+    raw = (raw or ''):gsub('^%s+', ''):gsub('%s+$', '')
+    raw = raw:gsub('^//', '')
+    return raw
+end
+
+local function validate_ipc_field(label, value)
+    if (value or ''):find('|', 1, true) then
+        msg(('%s cannot contain the | character because it breaks the current IPC protocol.'):format(label))
+        return false
+    end
+    return true
+end
+
 local function call_travel_router(dest)
     if not dest or dest == '' then return false end
     windower.send_command(('troute run %s'):format(dest))
@@ -50,7 +64,7 @@ local function on_ipc(data)
         end
 
         if op == 'command' then
-            local raw = parts[3] or ''
+            local raw = normalize_command(parts[3] or '')
             local from = parts[5] or 'unknown'
             if from == self_name() then return end
             msg(('Received command from %s: %s'):format(from, raw))
@@ -102,6 +116,10 @@ windower.register_event('addon command', function(...)
             return
         end
 
+        if not validate_ipc_field('Destination', dest) then
+            return
+        end
+
         msg(('Dispatching travel plan: %s'):format(dest))
         call_travel_router(dest)
         broadcast(('SESSION_CONDUCTOR|travel|%s|from|%s'):format(dest, self_name()))
@@ -109,9 +127,12 @@ windower.register_event('addon command', function(...)
     end
 
     if cmd == 'command' then
-        local raw = join(args, ' ', 2)
+        local raw = normalize_command(join(args, ' ', 2))
         if raw == '' then
             msg('Usage: //conductor command <raw windower command>')
+            return
+        end
+        if not validate_ipc_field('Command', raw) then
             return
         end
         msg(('Broadcasting command: %s'):format(raw))

--- a/addons/TravelRouter/README.md
+++ b/addons/TravelRouter/README.md
@@ -8,6 +8,10 @@ Content-aware travel routing addon for Windower.
 - Can execute helper commands for each step (`//troute run <dest>`).
 - Exposes a tiny IPC protocol that other addons (like SessionConductor) can call.
 
+## Install
+- Copy `addons/TravelRouter` into your Windower `addons/` directory.
+- Load with `//lua load TravelRouter`.
+
 ## Commands
 - `//troute list` — list known destinations
 - `//troute plan <destination>` — print route plan
@@ -25,11 +29,19 @@ Example step list:
 - `say:Take Survival Guide to Western Adoulin`
 
 ## IPC (v1)
-Inbound message type: `TRAVEL_ROUTER|plan|<destination>`
+Inbound message types:
+- `TRAVEL_ROUTER|plan|<destination>`
+- `TRAVEL_ROUTER|run|<destination>`
 
-Reply message type:
-`TRAVEL_ROUTER_REPLY|plan|<destination>|ok|<0/1>|steps|<N>`
+Reply message types:
+- `TRAVEL_ROUTER_REPLY|plan|<destination>|ok|<0/1>|steps|<N>`
+- `TRAVEL_ROUTER_REPLY|run|<destination>|ok|<0/1>`
 
 ---
 
 This is an MVP scaffold. Next iteration should include real zone/state awareness and unlock-aware route scoring.
+
+## Known limitations
+- Route definitions are static and bundled in `data/routes.lua`.
+- `//troute add ...` updates routes only for the current runtime session.
+- Route steps are thin wrappers around existing Windower commands; unlock/state validation is not implemented yet.

--- a/addons/TravelRouter/travelrouter.lua
+++ b/addons/TravelRouter/travelrouter.lua
@@ -10,14 +10,6 @@ local function msg(text)
     windower.add_to_chat(207, ('[TravelRouter] %s'):format(text))
 end
 
-local function split_words(input)
-    local out = {}
-    for part in input:gmatch('%S+') do
-        out[#out+1] = part
-    end
-    return out
-end
-
 local function join(tbl, sep, start_idx)
     local s = {}
     for i = start_idx or 1, #tbl do
@@ -28,6 +20,12 @@ end
 
 local function normalize_dest(dest)
     return (dest or ''):lower():gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+local function normalize_command(cmd)
+    cmd = (cmd or ''):gsub('^%s+', ''):gsub('%s+$', '')
+    cmd = cmd:gsub('^//', '')
+    return cmd
 end
 
 local function list_destinations()
@@ -62,7 +60,7 @@ local function execute_step(step)
     end
 
     if step:sub(1,4) == 'cmd:' then
-        local cmd = step:sub(5)
+        local cmd = normalize_command(step:sub(5))
         windower.send_command(cmd)
         msg(('exec: %s'):format(cmd))
         return


### PR DESCRIPTION
## Summary
- document how to install and smoke-test the prototype addons
- clarify that the prototypes are scaffolds rather than production-ready automation
- fix TravelRouter README IPC docs to include both `plan` and `run`
- normalize leading `//` in rebroadcast/executed commands and reject `|` in IPC payloads that would break the current delimiter-based protocol

## Why
The repo-level research is solid, but the addon prototypes were missing a few bits that make them easier to understand safely:
- no clear install/load instructions
- root README did not explain how the prototype addons fit into the repo
- TravelRouter docs under-described the implemented IPC surface
- SessionConductor accepted payloads that can break its own simple `|`-delimited IPC format

## Notes
This stays intentionally conservative:
- no new features or persistence layer
- no route data churn
- no expansion of the IPC model beyond documenting and hardening what already exists
