### PR TITLE
feat: AddonHealth v0.1, expanded routes, bug fixes, and polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Gaps worth building:
 ## 🗂️ Repository layout
 
 - `addons/` — complete Windower addons included with this project
+- `lib/` — shared Lua utility library (serialization, encoding, table helpers)
 - `specs/` — implementation specs and command surfaces
 - `docs/` — roadmap and reference links used during the landscape scan
 - catalog/index files in the repo root — generated research artifacts for analysis and filtering
@@ -88,6 +89,7 @@ Copy each addon folder into your Windower `addons/` directory, then load them in
 ```text
 //lua load TravelRouter
 //lua load SessionConductor
+//lua load AddonHealth
 ```
 
 Suggested smoke test:
@@ -95,8 +97,10 @@ Suggested smoke test:
 ```text
 //troute list
 //troute plan jeuno
+//troute search bastok
 //conductor ping
 //conductor travel jeuno
+//addonhealth check
 ```
 
 If you only load `SessionConductor`, the `travel` command will still broadcast, but actual route execution expects `TravelRouter` to be present on the receiving instance.
@@ -104,14 +108,22 @@ If you only load `SessionConductor`, the `travel` command will still broadcast, 
 ## 🧪 Addons included
 
 - `addons/TravelRouter` — content-aware travel route planner/executor
+  - 18 built-in destinations with fuzzy matching
+  - search, where, and version commands
 - `addons/SessionConductor` — multi-character command coordinator
   - integrates with TravelRouter via `//conductor travel <destination>`
   - includes v1.1 event/rule automation engine (`rules.default.lua` + overrides)
+  - mode-aware rule filtering and automatic stale request cleanup
+- `addons/AddonHealth` — in-game diagnostic dashboard for your addon stack
+  - detects conflicts, duplicates, and missing data directories
+  - background watch mode with alert suppression
+  - export diagnostic snapshots to file
 
 See specs:
 - `specs/travelrouter-v1.0.md`
 - `specs/sessionconductor-v1.0.md`
 - `specs/sessionconductor-v1.1-triggers.md` (event-driven automation model)
+- `specs/addonhealth-v0.1.md`
 
 ## ✅ Production checklist
 
@@ -133,6 +145,14 @@ See specs:
 - Connectivity check: `//conductor ping`
 - Verify travel orchestration: `//conductor travel jeuno`
 - Review ACK/timeouts: `//conductor status`
+
+### AddonHealth
+- Copy `addons/AddonHealth` into Windower `addons/`
+- Load: `//lua load AddonHealth`
+- Run diagnostics: `//addonhealth check`
+- List detected addons: `//addonhealth list`
+- Enable watch mode: `//addonhealth watch on`
+- Export report: `//addonhealth export`
 
 ### Safety defaults
 - Remote command execution is disabled by default.

--- a/addons/AddonHealth/README.md
+++ b/addons/AddonHealth/README.md
@@ -1,0 +1,34 @@
+# AddonHealth
+
+In-game health dashboard for your Windower addon stack.
+
+## Install
+- Copy `addons/AddonHealth` into your Windower `addons/` directory.
+- Load with `//lua load AddonHealth`.
+
+## What it does
+- Detects installed addons by scanning your Windower `addons/` directory.
+- Flags duplicate addon names (case-insensitive).
+- Detects known addon conflicts (e.g. GearSwap + GearSwap2).
+- Reports player state, zone, and party size.
+- Notes addons missing a `data/` directory (potential config issues).
+- Supports periodic background watch mode with alert suppression.
+- Exports diagnostic snapshots to timestamped report files.
+
+## Commands
+- `//addonhealth check` — run diagnostics and print report
+- `//addonhealth list` — list detected addons
+- `//addonhealth watch on|off [interval]` — toggle periodic checks (default 60s)
+- `//addonhealth export` — dump report to `data/addonhealth-report-<timestamp>.txt`
+- `//addonhealth status` — show watch state and last report time
+- `//addonhealth suppress [seconds]` — suppress watch alerts temporarily
+
+## Report contents
+- Player info (job, zone, party size)
+- Addon count and full list
+- Duplicate addon warnings
+- Known conflict detection
+- Missing data directory notes
+
+## Persistence
+- `data/` — exported report snapshots

--- a/addons/AddonHealth/addonhealth.lua
+++ b/addons/AddonHealth/addonhealth.lua
@@ -1,0 +1,305 @@
+_addon.name = 'AddonHealth'
+_addon.author = 'boostie'
+_addon.version = '0.1.0'
+_addon.commands = {'addonhealth', 'ahealth'}
+_addon.description = 'In-game health dashboard for Windower addon stack status and diagnostics.'
+
+local DATA_DIR = (windower.addon_path or '') .. 'data/'
+local CHECKS_DIR = (windower.addon_path or '') .. 'checks/'
+
+local state = {
+    watching = false,
+    watchInterval = 60,
+    lastWatchTick = 0,
+    lastReport = nil,
+    suppressUntil = 0,
+}
+
+local function msg(text)
+    windower.add_to_chat(6, ('[AddonHealth] %s'):format(text))
+end
+
+local function warn(text)
+    windower.add_to_chat(167, ('[AddonHealth] WARN: %s'):format(text))
+end
+
+local function normalize(s)
+    return (s or ''):lower():gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+local function join(tbl, sep, start_idx)
+    local s = {}
+    for i = start_idx or 1, #tbl do s[#s+1] = tbl[i] end
+    return table.concat(s, sep or ' ')
+end
+
+local function now()
+    return os.time()
+end
+
+local function get_loaded_addons()
+    local loaded = {}
+    local addons_path = windower.windower_path .. 'addons/'
+    local listing = windower.get_dir(addons_path)
+    if not listing then return loaded end
+
+    for _, name in ipairs(listing) do
+        local init_path = addons_path .. name .. '/init.lua'
+        local alt_path = addons_path .. name .. '/' .. name:lower() .. '.lua'
+        local f1 = io.open(init_path, 'r')
+        local f2 = io.open(alt_path, 'r')
+        local has_file = false
+        if f1 then f1:close(); has_file = true end
+        if f2 then f2:close(); has_file = true end
+        if has_file then
+            loaded[#loaded+1] = { name = name, path = addons_path .. name }
+        end
+    end
+    return loaded
+end
+
+local function check_loaded_list()
+    local results = {}
+    local addons = get_loaded_addons()
+    results.addon_count = #addons
+    results.addons = {}
+    for _, a in ipairs(addons) do
+        results.addons[#results.addons+1] = a.name
+    end
+    table.sort(results.addons)
+    return results
+end
+
+local function check_duplicates()
+    local results = { duplicates = {} }
+    local seen = {}
+    local addons = get_loaded_addons()
+    for _, a in ipairs(addons) do
+        local key = a.name:lower()
+        if seen[key] then
+            results.duplicates[#results.duplicates+1] = a.name
+        end
+        seen[key] = true
+    end
+    return results
+end
+
+local function check_data_dirs()
+    local results = { missing_data = {}, writable_issues = {} }
+    local addons = get_loaded_addons()
+    for _, a in ipairs(addons) do
+        local data_path = a.path .. '/data/'
+        local dir = windower.get_dir(data_path)
+        if not dir then
+            results.missing_data[#results.missing_data+1] = a.name
+        end
+    end
+    return results
+end
+
+local function check_known_conflicts()
+    local conflicts = {
+        {'GearSwap', 'GearSwap2'},
+        {'DressUp', 'DressMe'},
+        {'Shortcuts', 'ShortCommand'},
+    }
+    local results = { conflicts = {} }
+    local addons = get_loaded_addons()
+    local loaded_set = {}
+    for _, a in ipairs(addons) do loaded_set[a.name:lower()] = true end
+
+    for _, pair in ipairs(conflicts) do
+        local a, b = pair[1]:lower(), pair[2]:lower()
+        if loaded_set[a] and loaded_set[b] then
+            results.conflicts[#results.conflicts+1] = ('%s + %s'):format(pair[1], pair[2])
+        end
+    end
+    return results
+end
+
+local function check_player_state()
+    local results = {}
+    local player = windower.ffxi.get_player()
+    if not player then
+        results.player_available = false
+        return results
+    end
+    results.player_available = true
+    results.name = player.name
+    results.main_job = player.main_job or '?'
+    results.main_job_level = player.main_job_level or 0
+    results.sub_job = player.sub_job or '?'
+
+    local info = windower.ffxi.get_info() or {}
+    results.zone = info.zone or 0
+    results.logged_in = info.logged_in or false
+
+    local party = windower.ffxi.get_party() or {}
+    local count = 0
+    for i = 0, 5 do
+        local m = party['p' .. i]
+        if m and m.mob and m.mob.name then count = count + 1 end
+    end
+    results.party_size = count
+    return results
+end
+
+local function run_all_checks()
+    local report = {
+        ts = now(),
+        loaded = check_loaded_list(),
+        duplicates = check_duplicates(),
+        data_dirs = check_data_dirs(),
+        conflicts = check_known_conflicts(),
+        player = check_player_state(),
+    }
+    state.lastReport = report
+    return report
+end
+
+local function format_report(report)
+    local lines = {}
+    lines[#lines+1] = ('--- AddonHealth Report (%s) ---'):format(os.date('%Y-%m-%d %H:%M:%S', report.ts))
+
+    if report.player and report.player.player_available then
+        local p = report.player
+        lines[#lines+1] = ('Player: %s (%s%d/%s%d) Zone:%d Party:%d'):format(
+            p.name or '?', p.main_job or '?', p.main_job_level or 0,
+            p.sub_job or '?', 0, p.zone or 0, p.party_size or 0)
+    else
+        lines[#lines+1] = 'Player: not available (not logged in?)'
+    end
+
+    local loaded = report.loaded or {}
+    lines[#lines+1] = ('Addons detected: %d'):format(loaded.addon_count or 0)
+
+    local dups = report.duplicates or {}
+    if #(dups.duplicates or {}) > 0 then
+        lines[#lines+1] = ('WARN: Duplicate addons: %s'):format(table.concat(dups.duplicates, ', '))
+    end
+
+    local conflicts = report.conflicts or {}
+    if #(conflicts.conflicts or {}) > 0 then
+        lines[#lines+1] = ('WARN: Known conflicts: %s'):format(table.concat(conflicts.conflicts, ', '))
+    end
+
+    local data = report.data_dirs or {}
+    if #(data.missing_data or {}) > 0 then
+        lines[#lines+1] = ('Note: Addons without data/ dir: %s'):format(table.concat(data.missing_data, ', '))
+    end
+
+    lines[#lines+1] = '--- End Report ---'
+    return lines
+end
+
+local function print_report(report)
+    local lines = format_report(report)
+    for _, line in ipairs(lines) do msg(line) end
+end
+
+local function print_addon_list(report)
+    local loaded = report.loaded or {}
+    local addons = loaded.addons or {}
+    msg(('Detected addons (%d):'):format(#addons))
+    for i, name in ipairs(addons) do
+        msg(('  %d) %s'):format(i, name))
+    end
+end
+
+local function export_report(report)
+    local lines = format_report(report)
+    local filename = DATA_DIR .. ('addonhealth-report-%s.txt'):format(os.date('%Y%m%d-%H%M%S', report.ts))
+    local f = io.open(filename, 'w')
+    if not f then
+        msg('Failed to write report file.')
+        return
+    end
+    for _, line in ipairs(lines) do f:write(line, '\n') end
+
+    local loaded = report.loaded or {}
+    f:write('\nAddon list:\n')
+    for _, name in ipairs(loaded.addons or {}) do f:write('  - ', name, '\n') end
+    f:close()
+    msg(('Report exported to %s'):format(filename))
+end
+
+local function watch_tick()
+    if not state.watching then return end
+    local t = os.clock()
+    if t - state.lastWatchTick < state.watchInterval then return end
+    state.lastWatchTick = t
+
+    local report = run_all_checks()
+    local dups = report.duplicates or {}
+    local conflicts = report.conflicts or {}
+    local issues = #(dups.duplicates or {}) + #(conflicts.conflicts or {})
+
+    if issues > 0 and now() > state.suppressUntil then
+        warn(('%d issue(s) detected. Run //addonhealth check for details.'):format(issues))
+    end
+end
+
+windower.register_event('prerender', watch_tick)
+
+windower.register_event('addon command', function(...)
+    local args = {...}
+    local cmd = normalize(args[1])
+
+    if cmd == '' or cmd == 'help' then
+        msg('Commands: check | list | watch on|off [interval] | export | status')
+        return
+    end
+
+    if cmd == 'check' then
+        local report = run_all_checks()
+        print_report(report)
+        return
+    end
+
+    if cmd == 'list' then
+        local report = state.lastReport or run_all_checks()
+        print_addon_list(report)
+        return
+    end
+
+    if cmd == 'watch' then
+        local flag = normalize(args[2])
+        if flag == 'on' then
+            state.watching = true
+            local interval = tonumber(args[3])
+            if interval and interval >= 10 then state.watchInterval = interval end
+            msg(('Watch enabled (interval %ds)'):format(state.watchInterval))
+        elseif flag == 'off' then
+            state.watching = false
+            msg('Watch disabled.')
+        else
+            msg('Usage: //addonhealth watch on|off [interval_sec]')
+        end
+        return
+    end
+
+    if cmd == 'export' then
+        local report = state.lastReport or run_all_checks()
+        export_report(report)
+        return
+    end
+
+    if cmd == 'status' then
+        msg(('watch=%s interval=%ds lastReport=%s'):format(
+            tostring(state.watching),
+            state.watchInterval,
+            state.lastReport and os.date('%H:%M:%S', state.lastReport.ts) or 'none'))
+        return
+    end
+
+    if cmd == 'suppress' then
+        local sec = tonumber(args[2] or 300) or 300
+        state.suppressUntil = now() + sec
+        msg(('Suppressing alerts for %ds'):format(sec))
+        return
+    end
+
+    msg(('Unknown command "%s". Try //addonhealth help'):format(cmd))
+end)
+
+msg('AddonHealth v0.1.0 loaded. Use //addonhealth check to run diagnostics.')

--- a/addons/SessionConductor/data/rules.default.lua
+++ b/addons/SessionConductor/data/rules.default.lua
@@ -24,6 +24,7 @@ return {
     cooldown_sec = 8,
     lockout_group = 'recovery',
     lockout_sec = 3,
+    modes = {'normal', 'recovery'},
     when = {
       event = 'party.member.hp_low',
       where = {
@@ -74,6 +75,61 @@ return {
     },
     then_actions = {
       { kind = 'notify', text = 'Retry exhausted for remote request.' },
+    },
+  },
+  {
+    id = 'rule.combat.reengage_on_target_change',
+    enabled = false,
+    priority = 50,
+    cooldown_sec = 5,
+    lockout_group = 'combat_rotation',
+    lockout_sec = 3,
+    modes = {'normal'},
+    when = {
+      event = 'combat.target_changed',
+    },
+    then_actions = {
+      { kind = 'notify', text = 'Target changed, resyncing assist.' },
+      { kind = 'broadcast.command', cmd = 'input /assist <me>' },
+    },
+  },
+  {
+    id = 'rule.combat.disengage_notify',
+    enabled = true,
+    priority = 40,
+    cooldown_sec = 10,
+    modes = {'normal'},
+    when = {
+      event = 'combat.disengaged',
+    },
+    then_actions = {
+      { kind = 'notify', text = 'Combat disengaged.' },
+    },
+  },
+  {
+    id = 'rule.safety.ack_timeout_alert',
+    enabled = true,
+    priority = 90,
+    cooldown_sec = 15,
+    when = {
+      event = 'system.ack_timeout',
+    },
+    then_actions = {
+      { kind = 'notify', text = 'ACK timeout detected for pending request.' },
+    },
+  },
+  {
+    id = 'rule.safety.emergency_clear_on_engage',
+    enabled = true,
+    priority = 85,
+    cooldown_sec = 30,
+    modes = {'emergency', 'recovery'},
+    when = {
+      event = 'combat.engaged',
+    },
+    then_actions = {
+      { kind = 'mode.set', mode = 'normal' },
+      { kind = 'notify', text = 'Re-engaged, clearing emergency/recovery mode.' },
     },
   },
 }

--- a/addons/SessionConductor/sessionconductor.lua
+++ b/addons/SessionConductor/sessionconductor.lua
@@ -316,10 +316,21 @@ local function set_lockout(rule)
     state.lockouts[rule.lockout_group] = now() + math.max(1, dur)
 end
 
+local function check_rule_mode(rule)
+    local modes = rule.modes
+    if not modes then return true end
+    if type(modes) ~= 'table' then return true end
+    for _, m in ipairs(modes) do
+        if normalize(m) == normalize(state.mode) then return true end
+    end
+    return false
+end
+
 local function check_rule_event_match(rule, evt)
     local w = rule.when or {}
     if w.event and w.event ~= evt.type then return false end
     if not evaluate_where(evt, w.where) then return false end
+    if not check_rule_mode(rule) then return false end
     return true
 end
 
@@ -671,6 +682,11 @@ local function monitor_tick()
     end
 
     retry_pending()
+
+    local stale_cutoff = now() - 300
+    for req, p in pairs(state.pending) do
+        if p.sentAt < stale_cutoff then state.pending[req] = nil end
+    end
 end
 
 local function broadcast_v2(op, data)
@@ -690,7 +706,11 @@ local function handle_sc2(payload)
         local dest, req = m.dest or '', m.req or ''
         local ok = call_travel_router(dest)
         windower.send_ipc_message(pack('SC2R', { op = 'ack', req = req, from = self_name(), status = ok and 'ok' or 'fail' }))
-        emit_event('system.peer_unreachable', { req = req, peer = from, travel = dest, status = ok and 'ok' or 'fail' }, 'remote')
+        if ok then
+            emit_event('system.peer_travel_ok', { req = req, peer = from, destination = dest }, 'remote')
+        else
+            emit_event('system.peer_unreachable', { req = req, peer = from, destination = dest }, 'remote')
+        end
         return
     end
 
@@ -782,7 +802,20 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1])
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: travel|command|follow|ping|target|roster|status|timeout|remotecmd|auto|mode|pause|rule|rules|events|trace|emit')
+        msg('Commands: travel|command|follow|ping|target|roster|status|timeout|remotecmd|auto|mode|pause|rule|rules|events|trace|emit|version|clear')
+        return
+    end
+
+    if cmd == 'version' then
+        msg(('%s v%s by %s'):format(_addon.name, _addon.version, _addon.author))
+        return
+    end
+
+    if cmd == 'clear' then
+        local count = 0
+        for _ in pairs(state.pending) do count = count + 1 end
+        state.pending = {}
+        msg(('Cleared %d pending request(s).'):format(count))
         return
     end
 

--- a/addons/TravelRouter/data/routes.lua
+++ b/addons/TravelRouter/data/routes.lua
@@ -62,5 +62,302 @@ return {
         }
       }
     }
-  }
+  },
+
+  sandoria = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'say:Warp to Southern San d\'Oria via Home Point',
+          'cmd:hp San d\'Oria',
+          'say:Arrived in San d\'Oria'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 8,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp sandoria',
+          'say:Arrived in San d\'Oria'
+        }
+      }
+    }
+  },
+
+  bastok = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'say:Warp to Bastok Markets via Home Point',
+          'cmd:hp Bastok',
+          'say:Arrived in Bastok'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 8,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp bastok',
+          'say:Arrived in Bastok'
+        }
+      }
+    }
+  },
+
+  windurst = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'say:Warp to Windurst Woods via Home Point',
+          'cmd:hp Windurst',
+          'say:Arrived in Windurst'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 8,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp windurst',
+          'say:Arrived in Windurst'
+        }
+      }
+    }
+  },
+
+  selbina = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 14,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Selbina',
+          'say:Arrived in Selbina'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp selbina',
+          'say:Arrived in Selbina'
+        }
+      }
+    }
+  },
+
+  mhaura = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 14,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Mhaura',
+          'say:Arrived in Mhaura'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp mhaura',
+          'say:Arrived in Mhaura'
+        }
+      }
+    }
+  },
+
+  kazham = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 14,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Kazham',
+          'say:Arrived in Kazham'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp kazham',
+          'say:Arrived in Kazham'
+        }
+      }
+    }
+  },
+
+  rabao = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 14,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Rabao',
+          'say:Arrived in Rabao'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp rabao',
+          'say:Arrived in Rabao'
+        }
+      }
+    }
+  },
+
+  aht_urhgan = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'say:Warp to Aht Urhgan Whitegate via Home Point',
+          'cmd:hp Aht Urhgan Whitegate',
+          'say:Arrived in Whitegate'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 8,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp whitegate',
+          'say:Arrived in Whitegate'
+        }
+      }
+    }
+  },
+
+  nashmau = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 13,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Nashmau',
+          'say:Arrived in Nashmau'
+        }
+      }
+    }
+  },
+
+  tavnazia = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'cmd:hp Tavnazian Safehold',
+          'say:Arrived in Tavnazian Safehold'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp tavnazia',
+          'say:Arrived in Tavnazian Safehold'
+        }
+      }
+    }
+  },
+
+  escha_zitah = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 14,
+        requires = {'hp'},
+        steps = {
+          'cmd:hp Escha - Zi\'Tah',
+          'say:Arrived in Escha Zi\'Tah'
+        }
+      }
+    }
+  },
+
+  escha_ruaun = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 14,
+        requires = {'hp'},
+        steps = {
+          'cmd:hp Escha - Ru\'Aun',
+          'say:Arrived in Escha Ru\'Aun'
+        }
+      }
+    }
+  },
+
+  reisenjima = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 14,
+        requires = {'hp'},
+        steps = {
+          'cmd:hp Reisenjima',
+          'say:Arrived in Reisenjima'
+        }
+      }
+    }
+  },
+
+  abyssea_la_theine = {
+    candidates = {
+      {
+        name = 'waypoint',
+        score = 12,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp abyssea_la_theine',
+          'say:Arrived in Abyssea - La Theine'
+        }
+      }
+    }
+  },
+
+  dynamis_san_doria = {
+    candidates = {
+      {
+        name = 'warp-entry',
+        score = 10,
+        requires = {'warp'},
+        steps = {
+          'say:Travel to San d\'Oria first, then enter Dynamis',
+          'cmd:warp sandoria',
+          'wait:3',
+          'say:Proceed to Trail Markings for Dynamis entry'
+        }
+      }
+    }
+  },
 }

--- a/addons/TravelRouter/travelrouter.lua
+++ b/addons/TravelRouter/travelrouter.lua
@@ -92,6 +92,18 @@ local function save_user_state()
     msg(ok and ('Saved state to %s'):format(USER_STATE_FILE) or 'Failed to save state file.')
 end
 
+local function fuzzy_match_dest(dest)
+    local key = normalize(dest)
+    if routes[key] then return key end
+    for k, _ in pairs(routes) do
+        if k:find(key, 1, true) then return k end
+    end
+    for k, _ in pairs(routes) do
+        if key:find(k, 1, true) then return k end
+    end
+    return nil
+end
+
 local function route_candidates(dest)
     local route = routes[dest]
     if not route then return nil end
@@ -121,7 +133,8 @@ local function score_candidate(c)
 end
 
 local function pick_plan(dest)
-    local key = normalize(dest)
+    local key = fuzzy_match_dest(dest)
+    if not key then return nil, nil end
     local candidates = route_candidates(key)
     if not candidates then return nil, nil end
 
@@ -287,7 +300,34 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1])
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: list | plan <dest> | run <dest> | add <dest> <s1>;... | reset <dest> | unlock list|add|remove <k> | save')
+        msg('Commands: list | plan <dest> | run <dest> | add <dest> <s1>;... | reset <dest> | unlock list|add|remove <k> | save | where | search <term> | version')
+        return
+    end
+
+    if cmd == 'version' then
+        msg(('%s v%s by %s'):format(_addon.name, _addon.version, _addon.author))
+        return
+    end
+
+    if cmd == 'where' then
+        local info = windower.ffxi.get_info() or {}
+        msg(('Current zone: %s'):format(tostring(info.zone or 'unknown')))
+        return
+    end
+
+    if cmd == 'search' then
+        local term = normalize(join(args, ' ', 2))
+        if term == '' then msg('Usage: //troute search <term>'); return end
+        local matches = {}
+        for k, _ in pairs(routes) do
+            if k:find(term, 1, true) then matches[#matches+1] = k end
+        end
+        table.sort(matches)
+        if #matches > 0 then
+            msg(('Matching destinations (%d): %s'):format(#matches, table.concat(matches, ', ')))
+        else
+            msg(('No destinations matching "%s"'):format(term))
+        end
         return
     end
     if cmd == 'list' then list_destinations(); return end

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,10 +13,11 @@
 - [ ] Add confidence score for inferred categories
 
 ## Phase 3 (productize)
-- [ ] Publish static searchable site
+- [x] Publish static searchable site
 - [ ] Add tags and faceted filters (category, activity, popularity)
 - [ ] Add "starter addon ideas" page with implementation complexity
-- [ ] Ship first addon concept spec (`AddonHealth` or `OnboardingPilot`)
+- [x] Ship first addon concept spec (`AddonHealth`)
+- [x] Build AddonHealth v0.1 addon
 
 ## Contribution guidelines (draft)
 - Use PRs for repo additions/corrections

--- a/index.html
+++ b/index.html
@@ -10,39 +10,47 @@
     h1 { margin-bottom: .2rem; }
     .muted { color:#9fb0ff; margin-top:0; }
     input, select { padding:.6rem .7rem; border-radius:.5rem; border:1px solid #2b3666; background:#131a33; color:#e8ecff; }
-    .controls { display:flex; gap:.75rem; flex-wrap:wrap; margin:1rem 0 1.25rem; }
+    input:focus, select:focus { outline: 2px solid #5b8def; border-color: #5b8def; }
+    .controls { display:flex; gap:.75rem; flex-wrap:wrap; margin:1rem 0 .5rem; align-items: center; }
+    .result-count { color:#9fb0ff; font-size:.88rem; margin: 0 0 1rem; }
     table { width:100%; border-collapse: collapse; background:#0f1530; border:1px solid #27305c; }
     th, td { text-align:left; padding:.55rem .6rem; border-bottom:1px solid #1e2750; font-size:.92rem; vertical-align:top; }
-    th { position:sticky; top:0; background:#131a33; }
+    th { position:sticky; top:0; background:#131a33; cursor:pointer; user-select:none; white-space: nowrap; }
+    th:hover { background:#1a2448; }
+    th .sort-arrow { font-size:.7rem; margin-left:.3rem; opacity:.5; }
+    th .sort-arrow.active { opacity:1; }
     a { color:#8fc6ff; text-decoration:none; }
     a:hover { text-decoration:underline; }
     .tag { background:#1f2b58; border:1px solid #334179; padding:.1rem .4rem; border-radius:.4rem; font-size:.78rem; display:inline-block; }
+    .no-results { text-align:center; padding:2rem; color:#9fb0ff; }
+    tr:hover td { background:#151d3a; }
   </style>
 </head>
 <body>
   <h1>FFXI Addon Landscape</h1>
-  <p class="muted">Searchable index of FFXI addons across GitHub repos.</p>
+  <p class="muted">Searchable index of FFXI addons across GitHub repos. <a href="https://github.com/MrBoostie/ffxi-addon-landscape">View on GitHub</a></p>
 
   <div class="controls">
-    <input id="q" placeholder="Search addon/repo/category..." size="36" />
-    <select id="cat"><option value="">All categories</option></select>
-    <select id="minFresh">
+    <input id="q" placeholder="Search addon/repo/category..." size="36" aria-label="Search addons" />
+    <select id="cat" aria-label="Filter by category"><option value="">All categories</option></select>
+    <select id="minFresh" aria-label="Filter by freshness">
       <option value="0">Any freshness</option>
       <option value="5">Freshness 5 (≤6mo)</option>
       <option value="4">Freshness 4+ (≤1y)</option>
       <option value="3">Freshness 3+ (≤2y)</option>
     </select>
   </div>
+  <p class="result-count" id="count"></p>
 
-  <table>
+  <table role="grid">
     <thead>
       <tr>
-        <th>Addon</th>
+        <th data-sort="addon_name">Addon <span class="sort-arrow" id="sort-addon_name"></span></th>
         <th>Description</th>
-        <th>Category</th>
-        <th>Repos</th>
-        <th>Freshness</th>
-        <th>Score</th>
+        <th data-sort="category">Category <span class="sort-arrow" id="sort-category"></span></th>
+        <th data-sort="repo_count">Repos <span class="sort-arrow" id="sort-repo_count"></span></th>
+        <th data-sort="freshness_max">Freshness <span class="sort-arrow" id="sort-freshness_max"></span></th>
+        <th data-sort="opportunity_score">Score <span class="sort-arrow" id="sort-opportunity_score"></span></th>
       </tr>
     </thead>
     <tbody id="rows"></tbody>
@@ -50,31 +58,69 @@
 
 <script>
 let DATA=[];
+let sortKey='opportunity_score', sortDir=-1;
 const q=document.getElementById('q');
 const cat=document.getElementById('cat');
 const minFresh=document.getElementById('minFresh');
 const rows=document.getElementById('rows');
+const countEl=document.getElementById('count');
+
+function escapeHtml(s) {
+  const d = document.createElement('div');
+  d.textContent = s || '';
+  return d.innerHTML;
+}
 
 function render(){
   const needle=(q.value||'').toLowerCase().trim();
   const c=cat.value;
   const mf=Number(minFresh.value||0);
-  const filtered=DATA.filter(a=>{
+  let filtered=DATA.filter(a=>{
     if(c && a.category!==c) return false;
     if(a.freshness_max < mf) return false;
     if(!needle) return true;
     const blob=[a.addon_name,a.description||'',a.category,...a.repos].join(' ').toLowerCase();
     return blob.includes(needle);
   });
+
+  filtered.sort((a,b)=>{
+    let va=a[sortKey], vb=b[sortKey];
+    if(typeof va==='string') va=va.toLowerCase();
+    if(typeof vb==='string') vb=vb.toLowerCase();
+    if(va<vb) return -1*sortDir;
+    if(va>vb) return 1*sortDir;
+    return 0;
+  });
+
+  countEl.textContent=`Showing ${Math.min(filtered.length,500)} of ${filtered.length} addon${filtered.length===1?'':'s'} (${DATA.length} total)`;
+
+  document.querySelectorAll('.sort-arrow').forEach(el=>{el.textContent='';el.classList.remove('active');});
+  const arrow=document.getElementById('sort-'+sortKey);
+  if(arrow){arrow.textContent=sortDir>0?'\u25B2':'\u25BC';arrow.classList.add('active');}
+
+  if(filtered.length===0){
+    rows.innerHTML='<tr><td colspan="6" class="no-results">No addons match your filters.</td></tr>';
+    return;
+  }
+
   rows.innerHTML=filtered.slice(0,500).map(a=>`<tr>
-    <td><strong>${a.addon_name}</strong><br><span class="muted">${a.addon_key}</span></td>
-    <td>${a.description || '<span class="muted">No description yet</span>'}<br>${a.description_source && a.description_source !== 'heuristic' ? `<a class="muted" href="${a.description_source}" target="_blank" rel="noreferrer">source</a>` : `<span class="muted">source: heuristic</span>`}</td>
-    <td><span class="tag">${a.category}</span></td>
-    <td>${a.repos.map(r=>`<div><a href="https://github.com/${r}" target="_blank" rel="noreferrer">${r}</a></div>`).join('')}</td>
+    <td><strong>${escapeHtml(a.addon_name)}</strong><br><span class="muted">${escapeHtml(a.addon_key)}</span></td>
+    <td>${escapeHtml(a.description) || '<span class="muted">No description yet</span>'}<br>${a.description_source && a.description_source !== 'heuristic' ? `<a class="muted" href="${escapeHtml(a.description_source)}" target="_blank" rel="noreferrer">source</a>` : `<span class="muted">source: heuristic</span>`}</td>
+    <td><span class="tag">${escapeHtml(a.category)}</span></td>
+    <td>${(a.repos||[]).map(r=>`<div><a href="https://github.com/${escapeHtml(r)}" target="_blank" rel="noreferrer">${escapeHtml(r)}</a></div>`).join('')}</td>
     <td>${a.freshness_max}</td>
     <td>${a.opportunity_score}</td>
   </tr>`).join('');
 }
+
+document.querySelectorAll('th[data-sort]').forEach(th=>{
+  th.addEventListener('click',()=>{
+    const key=th.dataset.sort;
+    if(sortKey===key) sortDir*=-1;
+    else { sortKey=key; sortDir=-1; }
+    render();
+  });
+});
 
 fetch('./ffxi-addon-catalog-normalized.json').then(r=>r.json()).then(d=>{
   DATA=d;

--- a/lib/common.lua
+++ b/lib/common.lua
@@ -1,0 +1,85 @@
+local common = {}
+
+function common.normalize(s)
+    return (s or ''):lower():gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+function common.join(tbl, sep, start_idx)
+    local s = {}
+    for i = start_idx or 1, #tbl do s[#s+1] = tbl[i] end
+    return table.concat(s, sep or ' ')
+end
+
+function common.serialize_value(v, indent)
+    indent = indent or ''
+    if type(v) == 'string' then return string.format('%q', v) end
+    if type(v) == 'number' or type(v) == 'boolean' then return tostring(v) end
+    if type(v) == 'table' then
+        local n = indent .. '  '
+        local lines = {'{'}
+        for k, vv in pairs(v) do
+            local key = (type(k) == 'string' and k:match('^[%a_][%w_]*$')) and k or ('[' .. common.serialize_value(k) .. ']')
+            lines[#lines+1] = n .. key .. ' = ' .. common.serialize_value(vv, n) .. ','
+        end
+        lines[#lines+1] = indent .. '}'
+        return table.concat(lines, '\n')
+    end
+    return 'nil'
+end
+
+function common.write_table_file(path, t)
+    local f = io.open(path, 'w')
+    if not f then return false end
+    f:write('return ', common.serialize_value(t), '\n')
+    f:close()
+    return true
+end
+
+function common.load_table(path)
+    local ok, t = pcall(dofile, path)
+    if ok and type(t) == 'table' then return t end
+    return nil
+end
+
+function common.enc(s)
+    return tostring(s or ''):gsub('([^%w%-_%.~ ])', function(c) return string.format('%%%02X', string.byte(c)) end):gsub(' ', '+')
+end
+
+function common.dec(s)
+    s = (s or ''):gsub('+', ' ')
+    return s:gsub('%%(%x%x)', function(h) return string.char(tonumber(h, 16)) end)
+end
+
+function common.pack(prefix, t)
+    local parts = {}
+    for k, v in pairs(t or {}) do parts[#parts+1] = common.enc(k) .. '=' .. common.enc(v) end
+    return prefix .. '|' .. table.concat(parts, '&')
+end
+
+function common.unpack_payload(s)
+    local out = {}
+    for pair in (s or ''):gmatch('([^&]+)') do
+        local k, v = pair:match('([^=]+)=(.*)')
+        if k then out[common.dec(k)] = common.dec(v or '') end
+    end
+    return out
+end
+
+function common.copy_table(t)
+    local out = {}
+    for k, v in pairs(t or {}) do
+        if type(v) == 'table' then out[k] = common.copy_table(v) else out[k] = v end
+    end
+    return out
+end
+
+function common.self_name()
+    local p = windower.ffxi.get_player()
+    return (p and p.name) or 'unknown'
+end
+
+function common.now()
+    return os.time()
+end
+
+return common

--- a/prototypes/addonhealth/README.md
+++ b/prototypes/addonhealth/README.md
@@ -1,13 +1,5 @@
 # AddonHealth Prototype Scaffold
 
-This folder is a placeholder scaffold for the first implementation pass.
+This folder was the original placeholder scaffold.
 
-Planned structure:
-
-- `init.lua` — addon entrypoint
-- `commands.lua` — command routing (`//addonhealth ...`)
-- `checks/` — individual health checks
-- `render.lua` — HUD text rendering
-- `data/` — local snapshots/reports
-
-Status: scaffold only (no runtime code committed yet).
+The v0.1 implementation now lives at `addons/AddonHealth/`. See `specs/addonhealth-v0.1.md` for the spec and `addons/AddonHealth/README.md` for usage.


### PR DESCRIPTION
## Summary

- **New addon: AddonHealth v0.1** — in-game diagnostic dashboard that detects addon conflicts, duplicates, missing data directories, and reports player/party state. Includes background watch mode with alert suppression and timestamped report export.
- **SessionConductor bug fix + improvements** — fixed `peer_unreachable` event incorrectly emitted on successful travel; added mode-aware rule filtering (`modes` field on rules), automatic stale request cleanup (>5min), `clear` and `version` commands, and 4 new default rules (reengage, disengage notify, ACK timeout alert, emergency auto-clear).
- **TravelRouter expansion** — grew route data from 3 to 18 destinations (all starter cities, Whitegate, Tavnazia, Escha zones, Abyssea, Dynamis). Added fuzzy destination matching, `search`, `where`, and `version` commands.
- **Shared utility library** (`lib/common.lua`) — extracted duplicated serialization, URL encoding, and table helpers for reuse across addons.
- **index.html improvements** — clickable column sorting, result count display, HTML escaping (XSS fix), empty state message, row hover highlights, ARIA labels for accessibility.
- **Docs & roadmap updates** — README expanded with AddonHealth docs and production checklist; roadmap updated to reflect completed milestones.

## Test plan

- [ ] Verify Lua syntax: all `.lua` files pass balanced block analysis (functions/if/for/while vs end counts)
- [ ] Verify JSON catalog files parse without errors
- [ ] Verify `index.html` renders correctly with sorting and filtering
- [ ] Smoke test `//addonhealth check` in Windower
- [ ] Smoke test `//troute search bastok` and `//troute plan sandoria` for new destinations
- [ ] Smoke test `//conductor version` and `//conductor clear`
- [ ] Verify mode-aware rules: rules with `modes = {'normal'}` should not fire in emergency mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)