### PR TITLE
Level up addon observability and route tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Gaps worth building:
 ## 🗂️ Repository layout
 
 - `addons/` — complete Windower addons included with this project
+- `lib/` — shared Lua utility library (serialization, encoding, table helpers)
 - `specs/` — implementation specs and command surfaces
 - `docs/` — roadmap and reference links used during the landscape scan
 - catalog/index files in the repo root — generated research artifacts for analysis and filtering
@@ -88,6 +89,7 @@ Copy each addon folder into your Windower `addons/` directory, then load them in
 ```text
 //lua load TravelRouter
 //lua load SessionConductor
+//lua load AddonHealth
 ```
 
 Suggested smoke test:
@@ -95,8 +97,10 @@ Suggested smoke test:
 ```text
 //troute list
 //troute plan jeuno
+//troute search bastok
 //conductor ping
 //conductor travel jeuno
+//addonhealth check
 ```
 
 If you only load `SessionConductor`, the `travel` command will still broadcast, but actual route execution expects `TravelRouter` to be present on the receiving instance.
@@ -104,14 +108,22 @@ If you only load `SessionConductor`, the `travel` command will still broadcast, 
 ## 🧪 Addons included
 
 - `addons/TravelRouter` — content-aware travel route planner/executor
+  - 18 built-in destinations with fuzzy matching
+  - search, where, and version commands
 - `addons/SessionConductor` — multi-character command coordinator
   - integrates with TravelRouter via `//conductor travel <destination>`
   - includes v1.1 event/rule automation engine (`rules.default.lua` + overrides)
+  - mode-aware rule filtering and automatic stale request cleanup
+- `addons/AddonHealth` — in-game diagnostic dashboard for your addon stack
+  - detects conflicts, duplicates, and missing data directories
+  - background watch mode with alert suppression
+  - export diagnostic snapshots to file
 
 See specs:
 - `specs/travelrouter-v1.0.md`
 - `specs/sessionconductor-v1.0.md`
 - `specs/sessionconductor-v1.1-triggers.md` (event-driven automation model)
+- `specs/addonhealth-v0.1.md`
 
 ## ✅ Production checklist
 
@@ -133,6 +145,14 @@ See specs:
 - Connectivity check: `//conductor ping`
 - Verify travel orchestration: `//conductor travel jeuno`
 - Review ACK/timeouts: `//conductor status`
+
+### AddonHealth
+- Copy `addons/AddonHealth` into Windower `addons/`
+- Load: `//lua load AddonHealth`
+- Run diagnostics: `//addonhealth check`
+- List detected addons: `//addonhealth list`
+- Enable watch mode: `//addonhealth watch on`
+- Export report: `//addonhealth export`
 
 ### Safety defaults
 - Remote command execution is disabled by default.

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ Suggested smoke test:
 
 ```text
 //troute list
-//troute plan jeuno
-//troute search bastok
+//troute explain jeuno
+//troute history 5
 //conductor ping
-//conductor travel jeuno
-//addonhealth check
+//conductor status detail
+//addonhealth summary
 ```
 
 If you only load `SessionConductor`, the `travel` command will still broadcast, but actual route execution expects `TravelRouter` to be present on the receiving instance.

--- a/addons/AddonHealth/README.md
+++ b/addons/AddonHealth/README.md
@@ -1,0 +1,34 @@
+# AddonHealth
+
+In-game health dashboard for your Windower addon stack.
+
+## Install
+- Copy `addons/AddonHealth` into your Windower `addons/` directory.
+- Load with `//lua load AddonHealth`.
+
+## What it does
+- Detects installed addons by scanning your Windower `addons/` directory.
+- Flags duplicate addon names (case-insensitive).
+- Detects known addon conflicts (e.g. GearSwap + GearSwap2).
+- Reports player state, zone, and party size.
+- Notes addons missing a `data/` directory (potential config issues).
+- Supports periodic background watch mode with alert suppression.
+- Exports diagnostic snapshots to timestamped report files.
+
+## Commands
+- `//addonhealth check` — run diagnostics and print report
+- `//addonhealth list` — list detected addons
+- `//addonhealth watch on|off [interval]` — toggle periodic checks (default 60s)
+- `//addonhealth export` — dump report to `data/addonhealth-report-<timestamp>.txt`
+- `//addonhealth status` — show watch state and last report time
+- `//addonhealth suppress [seconds]` — suppress watch alerts temporarily
+
+## Report contents
+- Player info (job, zone, party size)
+- Addon count and full list
+- Duplicate addon warnings
+- Known conflict detection
+- Missing data directory notes
+
+## Persistence
+- `data/` — exported report snapshots

--- a/addons/AddonHealth/README.md
+++ b/addons/AddonHealth/README.md
@@ -1,34 +1,30 @@
 # AddonHealth
 
-In-game health dashboard for your Windower addon stack.
+In-game diagnostic dashboard for your Windower addon stack with watch mode, severity grading, and short report history.
 
 ## Install
 - Copy `addons/AddonHealth` into your Windower `addons/` directory.
 - Load with `//lua load AddonHealth`.
 
 ## What it does
-- Detects installed addons by scanning your Windower `addons/` directory.
-- Flags duplicate addon names (case-insensitive).
-- Detects known addon conflicts (e.g. GearSwap + GearSwap2).
+- Detects installed addons by scanning your Windower addons directory.
+- Flags duplicate addon names and known addon conflicts.
 - Reports player state, zone, and party size.
-- Notes addons missing a `data/` directory (potential config issues).
-- Supports periodic background watch mode with alert suppression.
-- Exports diagnostic snapshots to timestamped report files.
+- Notes addons missing a `data/` directory.
+- Supports periodic watch mode with alert suppression.
+- Assigns a simple severity level and keeps a short in-memory history of reports.
+- Exports diagnostic snapshots to timestamped text files.
 
 ## Commands
-- `//addonhealth check` — run diagnostics and print report
+- `//addonhealth check` — run diagnostics and print the full report
+- `//addonhealth summary` — print a compact severity summary
 - `//addonhealth list` — list detected addons
-- `//addonhealth watch on|off [interval]` — toggle periodic checks (default 60s)
+- `//addonhealth history [N]` — show recent in-memory report history
+- `//addonhealth watch on|off [interval]` — toggle periodic checks
 - `//addonhealth export` — dump report to `data/addonhealth-report-<timestamp>.txt`
 - `//addonhealth status` — show watch state and last report time
 - `//addonhealth suppress [seconds]` — suppress watch alerts temporarily
 
-## Report contents
-- Player info (job, zone, party size)
-- Addon count and full list
-- Duplicate addon warnings
-- Known conflict detection
-- Missing data directory notes
-
-## Persistence
-- `data/` — exported report snapshots
+## Notes
+- Severity is intentionally coarse: `ok`, `warn`, or `alert`.
+- History is in-memory only and intended for short-session diagnostics.

--- a/addons/AddonHealth/addonhealth.lua
+++ b/addons/AddonHealth/addonhealth.lua
@@ -1,6 +1,6 @@
 _addon.name = 'AddonHealth'
 _addon.author = 'boostie'
-_addon.version = '0.1.0'
+_addon.version = '0.2.0'
 _addon.commands = {'addonhealth', 'ahealth'}
 _addon.description = 'In-game health dashboard for Windower addon stack status and diagnostics.'
 
@@ -13,6 +13,8 @@ local state = {
     lastWatchTick = 0,
     lastReport = nil,
     suppressUntil = 0,
+    history = {},
+    historyLimit = 10,
 }
 
 local function msg(text)
@@ -144,6 +146,21 @@ local function check_player_state()
     return results
 end
 
+local function remember_report(report)
+    state.history[#state.history+1] = report
+    while #state.history > state.historyLimit do table.remove(state.history, 1) end
+end
+
+local function severity_for_report(report)
+    local issues = 0
+    issues = issues + #((report.duplicates and report.duplicates.duplicates) or {})
+    issues = issues + #((report.conflicts and report.conflicts.conflicts) or {})
+    issues = issues + #((report.data_dirs and report.data_dirs.missing_data) or {})
+    if issues == 0 then return 'ok' end
+    if issues <= 2 then return 'warn' end
+    return 'alert'
+end
+
 local function run_all_checks()
     local report = {
         ts = now(),
@@ -153,7 +170,9 @@ local function run_all_checks()
         conflicts = check_known_conflicts(),
         player = check_player_state(),
     }
+    report.severity = severity_for_report(report)
     state.lastReport = report
+    remember_report(report)
     return report
 end
 
@@ -171,6 +190,7 @@ local function format_report(report)
     end
 
     local loaded = report.loaded or {}
+    lines[#lines+1] = ('Severity: %s'):format(report.severity or 'unknown')
     lines[#lines+1] = ('Addons detected: %d'):format(loaded.addon_count or 0)
 
     local dups = report.duplicates or {}
@@ -203,6 +223,26 @@ local function print_addon_list(report)
     msg(('Detected addons (%d):'):format(#addons))
     for i, name in ipairs(addons) do
         msg(('  %d) %s'):format(i, name))
+    end
+end
+
+local function print_summary(report)
+    msg(('Severity=%s addons=%d duplicates=%d conflicts=%d missing_data=%d'):format(
+        tostring(report.severity or 'unknown'),
+        tonumber((report.loaded and report.loaded.addon_count) or 0),
+        #((report.duplicates and report.duplicates.duplicates) or {}),
+        #((report.conflicts and report.conflicts.conflicts) or {}),
+        #((report.data_dirs and report.data_dirs.missing_data) or {})
+    ))
+end
+
+local function history_report(limit)
+    local n = tonumber(limit) or #state.history
+    if #state.history == 0 then msg('No report history yet.') return end
+    local start_idx = math.max(1, #state.history - n + 1)
+    for i = start_idx, #state.history do
+        local r = state.history[i]
+        msg(('%s severity=%s addons=%d'):format(os.date('%Y-%m-%d %H:%M:%S', r.ts or os.time()), tostring(r.severity or 'unknown'), tonumber((r.loaded and r.loaded.addon_count) or 0)))
     end
 end
 
@@ -246,13 +286,19 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1])
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: check | list | watch on|off [interval] | export | status')
+        msg('Commands: check | summary | list | history [N] | watch on|off [interval] | export | status | suppress [seconds]')
         return
     end
 
     if cmd == 'check' then
         local report = run_all_checks()
         print_report(report)
+        return
+    end
+
+    if cmd == 'summary' then
+        local report = state.lastReport or run_all_checks()
+        print_summary(report)
         return
     end
 
@@ -284,6 +330,11 @@ windower.register_event('addon command', function(...)
         return
     end
 
+    if cmd == 'history' then
+        history_report(args[2])
+        return
+    end
+
     if cmd == 'status' then
         msg(('watch=%s interval=%ds lastReport=%s'):format(
             tostring(state.watching),
@@ -302,4 +353,4 @@ windower.register_event('addon command', function(...)
     msg(('Unknown command "%s". Try //addonhealth help'):format(cmd))
 end)
 
-msg('AddonHealth v0.1.0 loaded. Use //addonhealth check to run diagnostics.')
+msg('AddonHealth v0.2.0 loaded. Use //addonhealth check to run diagnostics.')

--- a/addons/AddonHealth/addonhealth.lua
+++ b/addons/AddonHealth/addonhealth.lua
@@ -1,0 +1,305 @@
+_addon.name = 'AddonHealth'
+_addon.author = 'boostie'
+_addon.version = '0.1.0'
+_addon.commands = {'addonhealth', 'ahealth'}
+_addon.description = 'In-game health dashboard for Windower addon stack status and diagnostics.'
+
+local DATA_DIR = (windower.addon_path or '') .. 'data/'
+local CHECKS_DIR = (windower.addon_path or '') .. 'checks/'
+
+local state = {
+    watching = false,
+    watchInterval = 60,
+    lastWatchTick = 0,
+    lastReport = nil,
+    suppressUntil = 0,
+}
+
+local function msg(text)
+    windower.add_to_chat(6, ('[AddonHealth] %s'):format(text))
+end
+
+local function warn(text)
+    windower.add_to_chat(167, ('[AddonHealth] WARN: %s'):format(text))
+end
+
+local function normalize(s)
+    return (s or ''):lower():gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+local function join(tbl, sep, start_idx)
+    local s = {}
+    for i = start_idx or 1, #tbl do s[#s+1] = tbl[i] end
+    return table.concat(s, sep or ' ')
+end
+
+local function now()
+    return os.time()
+end
+
+local function get_loaded_addons()
+    local loaded = {}
+    local addons_path = windower.windower_path .. 'addons/'
+    local listing = windower.get_dir(addons_path)
+    if not listing then return loaded end
+
+    for _, name in ipairs(listing) do
+        local init_path = addons_path .. name .. '/init.lua'
+        local alt_path = addons_path .. name .. '/' .. name:lower() .. '.lua'
+        local f1 = io.open(init_path, 'r')
+        local f2 = io.open(alt_path, 'r')
+        local has_file = false
+        if f1 then f1:close(); has_file = true end
+        if f2 then f2:close(); has_file = true end
+        if has_file then
+            loaded[#loaded+1] = { name = name, path = addons_path .. name }
+        end
+    end
+    return loaded
+end
+
+local function check_loaded_list()
+    local results = {}
+    local addons = get_loaded_addons()
+    results.addon_count = #addons
+    results.addons = {}
+    for _, a in ipairs(addons) do
+        results.addons[#results.addons+1] = a.name
+    end
+    table.sort(results.addons)
+    return results
+end
+
+local function check_duplicates()
+    local results = { duplicates = {} }
+    local seen = {}
+    local addons = get_loaded_addons()
+    for _, a in ipairs(addons) do
+        local key = a.name:lower()
+        if seen[key] then
+            results.duplicates[#results.duplicates+1] = a.name
+        end
+        seen[key] = true
+    end
+    return results
+end
+
+local function check_data_dirs()
+    local results = { missing_data = {}, writable_issues = {} }
+    local addons = get_loaded_addons()
+    for _, a in ipairs(addons) do
+        local data_path = a.path .. '/data/'
+        local dir = windower.get_dir(data_path)
+        if not dir then
+            results.missing_data[#results.missing_data+1] = a.name
+        end
+    end
+    return results
+end
+
+local function check_known_conflicts()
+    local conflicts = {
+        {'GearSwap', 'GearSwap2'},
+        {'DressUp', 'DressMe'},
+        {'Shortcuts', 'ShortCommand'},
+    }
+    local results = { conflicts = {} }
+    local addons = get_loaded_addons()
+    local loaded_set = {}
+    for _, a in ipairs(addons) do loaded_set[a.name:lower()] = true end
+
+    for _, pair in ipairs(conflicts) do
+        local a, b = pair[1]:lower(), pair[2]:lower()
+        if loaded_set[a] and loaded_set[b] then
+            results.conflicts[#results.conflicts+1] = ('%s + %s'):format(pair[1], pair[2])
+        end
+    end
+    return results
+end
+
+local function check_player_state()
+    local results = {}
+    local player = windower.ffxi.get_player()
+    if not player then
+        results.player_available = false
+        return results
+    end
+    results.player_available = true
+    results.name = player.name
+    results.main_job = player.main_job or '?'
+    results.main_job_level = player.main_job_level or 0
+    results.sub_job = player.sub_job or '?'
+
+    local info = windower.ffxi.get_info() or {}
+    results.zone = info.zone or 0
+    results.logged_in = info.logged_in or false
+
+    local party = windower.ffxi.get_party() or {}
+    local count = 0
+    for i = 0, 5 do
+        local m = party['p' .. i]
+        if m and m.mob and m.mob.name then count = count + 1 end
+    end
+    results.party_size = count
+    return results
+end
+
+local function run_all_checks()
+    local report = {
+        ts = now(),
+        loaded = check_loaded_list(),
+        duplicates = check_duplicates(),
+        data_dirs = check_data_dirs(),
+        conflicts = check_known_conflicts(),
+        player = check_player_state(),
+    }
+    state.lastReport = report
+    return report
+end
+
+local function format_report(report)
+    local lines = {}
+    lines[#lines+1] = ('--- AddonHealth Report (%s) ---'):format(os.date('%Y-%m-%d %H:%M:%S', report.ts))
+
+    if report.player and report.player.player_available then
+        local p = report.player
+        lines[#lines+1] = ('Player: %s (%s%d/%s%d) Zone:%d Party:%d'):format(
+            p.name or '?', p.main_job or '?', p.main_job_level or 0,
+            p.sub_job or '?', 0, p.zone or 0, p.party_size or 0)
+    else
+        lines[#lines+1] = 'Player: not available (not logged in?)'
+    end
+
+    local loaded = report.loaded or {}
+    lines[#lines+1] = ('Addons detected: %d'):format(loaded.addon_count or 0)
+
+    local dups = report.duplicates or {}
+    if #(dups.duplicates or {}) > 0 then
+        lines[#lines+1] = ('WARN: Duplicate addons: %s'):format(table.concat(dups.duplicates, ', '))
+    end
+
+    local conflicts = report.conflicts or {}
+    if #(conflicts.conflicts or {}) > 0 then
+        lines[#lines+1] = ('WARN: Known conflicts: %s'):format(table.concat(conflicts.conflicts, ', '))
+    end
+
+    local data = report.data_dirs or {}
+    if #(data.missing_data or {}) > 0 then
+        lines[#lines+1] = ('Note: Addons without data/ dir: %s'):format(table.concat(data.missing_data, ', '))
+    end
+
+    lines[#lines+1] = '--- End Report ---'
+    return lines
+end
+
+local function print_report(report)
+    local lines = format_report(report)
+    for _, line in ipairs(lines) do msg(line) end
+end
+
+local function print_addon_list(report)
+    local loaded = report.loaded or {}
+    local addons = loaded.addons or {}
+    msg(('Detected addons (%d):'):format(#addons))
+    for i, name in ipairs(addons) do
+        msg(('  %d) %s'):format(i, name))
+    end
+end
+
+local function export_report(report)
+    local lines = format_report(report)
+    local filename = DATA_DIR .. ('addonhealth-report-%s.txt'):format(os.date('%Y%m%d-%H%M%S', report.ts))
+    local f = io.open(filename, 'w')
+    if not f then
+        msg('Failed to write report file.')
+        return
+    end
+    for _, line in ipairs(lines) do f:write(line, '\n') end
+
+    local loaded = report.loaded or {}
+    f:write('\nAddon list:\n')
+    for _, name in ipairs(loaded.addons or {}) do f:write('  - ', name, '\n') end
+    f:close()
+    msg(('Report exported to %s'):format(filename))
+end
+
+local function watch_tick()
+    if not state.watching then return end
+    local t = os.clock()
+    if t - state.lastWatchTick < state.watchInterval then return end
+    state.lastWatchTick = t
+
+    local report = run_all_checks()
+    local dups = report.duplicates or {}
+    local conflicts = report.conflicts or {}
+    local issues = #(dups.duplicates or {}) + #(conflicts.conflicts or {})
+
+    if issues > 0 and now() > state.suppressUntil then
+        warn(('%d issue(s) detected. Run //addonhealth check for details.'):format(issues))
+    end
+end
+
+windower.register_event('prerender', watch_tick)
+
+windower.register_event('addon command', function(...)
+    local args = {...}
+    local cmd = normalize(args[1])
+
+    if cmd == '' or cmd == 'help' then
+        msg('Commands: check | list | watch on|off [interval] | export | status')
+        return
+    end
+
+    if cmd == 'check' then
+        local report = run_all_checks()
+        print_report(report)
+        return
+    end
+
+    if cmd == 'list' then
+        local report = state.lastReport or run_all_checks()
+        print_addon_list(report)
+        return
+    end
+
+    if cmd == 'watch' then
+        local flag = normalize(args[2])
+        if flag == 'on' then
+            state.watching = true
+            local interval = tonumber(args[3])
+            if interval and interval >= 10 then state.watchInterval = interval end
+            msg(('Watch enabled (interval %ds)'):format(state.watchInterval))
+        elseif flag == 'off' then
+            state.watching = false
+            msg('Watch disabled.')
+        else
+            msg('Usage: //addonhealth watch on|off [interval_sec]')
+        end
+        return
+    end
+
+    if cmd == 'export' then
+        local report = state.lastReport or run_all_checks()
+        export_report(report)
+        return
+    end
+
+    if cmd == 'status' then
+        msg(('watch=%s interval=%ds lastReport=%s'):format(
+            tostring(state.watching),
+            state.watchInterval,
+            state.lastReport and os.date('%H:%M:%S', state.lastReport.ts) or 'none'))
+        return
+    end
+
+    if cmd == 'suppress' then
+        local sec = tonumber(args[2] or 300) or 300
+        state.suppressUntil = now() + sec
+        msg(('Suppressing alerts for %ds'):format(sec))
+        return
+    end
+
+    msg(('Unknown command "%s". Try //addonhealth help'):format(cmd))
+end)
+
+msg('AddonHealth v0.1.0 loaded. Use //addonhealth check to run diagnostics.')

--- a/addons/SessionConductor/README.md
+++ b/addons/SessionConductor/README.md
@@ -1,17 +1,18 @@
 # SessionConductor
 
-Multi-character session conductor addon for Windower.
+Event-driven multi-character orchestration for Windower with rule evaluation, ACK tracking, pending request inspection, and safer follow command construction.
 
 ## Install
 - Copy `addons/SessionConductor` into your Windower `addons/` directory.
 - Load with `//lua load SessionConductor`.
-- For coordinated travel, also load `TravelRouter` on each participating instance.
 
 ## What it does
-- Broadcasts coordinated travel/command operations over IPC.
-- Integrates with **TravelRouter** for synchronized destination routing.
-- Supports roster groups and target scoping (`all` or specific group).
-- Tracks ACK replies per dispatch and reports timeout state.
+- Dispatches travel and command actions to trusted peers over IPC.
+- Tracks ACK replies per request and retries lightweight peer actions.
+- Supports scoped rosters for different teams or play patterns.
+- Evaluates trigger rules against local game-state-derived events.
+- Records an append-only event log for debugging automation behavior.
+- Hardens follow command construction and improves operator introspection.
 
 ## Commands
 ### Core dispatch
@@ -24,14 +25,18 @@ Multi-character session conductor addon for Windower.
 - `//conductor target <group|all>`
 - `//conductor roster add <group> <name>`
 - `//conductor roster remove <group> <name>`
+- `//conductor roster show <group>`
 - `//conductor roster list`
 
 ### Reliability / safety
 - `//conductor timeout <seconds>`
 - `//conductor status`
+- `//conductor status detail`
+- `//conductor pending [N]`
 - `//conductor remotecmd on|off`
+- `//conductor localecho on|off`
 
-### Event/rule automation (v1.1)
+### Event/rule automation
 - `//conductor auto on|off`
 - `//conductor mode <normal|recovery|emergency|travel>`
 - `//conductor pause <seconds>`
@@ -47,30 +52,10 @@ Multi-character session conductor addon for Windower.
 ## Persistence
 - `data/roster.user.lua` stores groups, target selection, timeout, and automation toggles.
 - `data/rules.default.lua` shipped baseline trigger rules.
-- `data/rules.user.lua` optional user overrides (same rule ids override defaults).
-- `data/events.log` rolling append-only event trail for debugging.
+- `data/rules.user.lua` optional user overrides.
+- `data/events.log` rolling append-only event trail.
 
-## Integration behavior
-When `travel` is used:
-1. SessionConductor executes TravelRouter locally.
-2. Sends IPC event containing request id + target scope.
-3. Peers matching scope execute route and ACK result.
-
-## IPC
-### v2 (preferred, robust payload encoding)
-- `SC2|op=travel&dest=jeuno&from=Alice&target=farm&req=...`
-- `SC2|op=command&raw=input+/heal+Bob&from=Alice&target=all&req=...`
-- `SC2|op=ping&from=Alice&target=all`
-- `SC2R|op=ack&req=...&from=Bob&status=ok`
-- `SC2R|op=pong&from=Bob`
-
-### v1 (legacy compatibility during migration)
-- `SESSION_CONDUCTOR|travel|...`
-- `SESSION_CONDUCTOR|command|...`
-- `SESSION_CONDUCTOR|ping|...`
-- `SESSION_CONDUCTOR_REPLY|pong|...`
-
-## Safety / scope notes
-- This is trusted-party tooling, not a hardened remote-control framework.
-- Remote command execution is OFF by default; enable only for trusted groups (`//conductor remotecmd on`).
-- ACK/timeout reporting is lightweight and intentionally simple.
+## Notes
+- This remains trusted-party tooling, not an exposed remote control service.
+- Remote command execution is still opt-in and off by default.
+- The new pending/status views are there so operators can see what the automation layer thinks is happening instead of guessing.

--- a/addons/SessionConductor/data/rules.default.lua
+++ b/addons/SessionConductor/data/rules.default.lua
@@ -24,6 +24,7 @@ return {
     cooldown_sec = 8,
     lockout_group = 'recovery',
     lockout_sec = 3,
+    modes = {'normal', 'recovery'},
     when = {
       event = 'party.member.hp_low',
       where = {
@@ -74,6 +75,61 @@ return {
     },
     then_actions = {
       { kind = 'notify', text = 'Retry exhausted for remote request.' },
+    },
+  },
+  {
+    id = 'rule.combat.reengage_on_target_change',
+    enabled = false,
+    priority = 50,
+    cooldown_sec = 5,
+    lockout_group = 'combat_rotation',
+    lockout_sec = 3,
+    modes = {'normal'},
+    when = {
+      event = 'combat.target_changed',
+    },
+    then_actions = {
+      { kind = 'notify', text = 'Target changed, resyncing assist.' },
+      { kind = 'broadcast.command', cmd = 'input /assist <me>' },
+    },
+  },
+  {
+    id = 'rule.combat.disengage_notify',
+    enabled = true,
+    priority = 40,
+    cooldown_sec = 10,
+    modes = {'normal'},
+    when = {
+      event = 'combat.disengaged',
+    },
+    then_actions = {
+      { kind = 'notify', text = 'Combat disengaged.' },
+    },
+  },
+  {
+    id = 'rule.safety.ack_timeout_alert',
+    enabled = true,
+    priority = 90,
+    cooldown_sec = 15,
+    when = {
+      event = 'system.ack_timeout',
+    },
+    then_actions = {
+      { kind = 'notify', text = 'ACK timeout detected for pending request.' },
+    },
+  },
+  {
+    id = 'rule.safety.emergency_clear_on_engage',
+    enabled = true,
+    priority = 85,
+    cooldown_sec = 30,
+    modes = {'emergency', 'recovery'},
+    when = {
+      event = 'combat.engaged',
+    },
+    then_actions = {
+      { kind = 'mode.set', mode = 'normal' },
+      { kind = 'notify', text = 'Re-engaged, clearing emergency/recovery mode.' },
     },
   },
 }

--- a/addons/SessionConductor/sessionconductor.lua
+++ b/addons/SessionConductor/sessionconductor.lua
@@ -1,6 +1,6 @@
 _addon.name = 'SessionConductor'
 _addon.author = 'boostie'
-_addon.version = '1.1.0'
+_addon.version = '1.2.0'
 _addon.commands = {'conductor', 'sconduct'}
 _addon.description = 'Event-driven multi-character orchestration with rules, ACKs, and safety rails.'
 
@@ -29,6 +29,7 @@ local state = {
     eventHistory = {},
     historyLimit = 200,
     trace = false,
+    localEcho = true,
 
     globalActionWindowSec = 10,
     globalActionMax = 5,
@@ -187,6 +188,18 @@ local function in_target_group(name, target)
     local group = state.rosters[target] or {}
     for _, n in ipairs(group) do if normalize(n) == normalize(name) then return true end end
     return false
+end
+
+local function shell_escape_arg(text)
+    local s = tostring(text or '')
+    return '"' .. s:gsub('([\"])', '\\%1') .. '"'
+end
+
+local function send_safe_command(raw)
+    local cmd = normalize_command(raw or '')
+    if cmd == '' then return false end
+    windower.send_command(cmd)
+    return true
 end
 
 local function sender_trusted(name)
@@ -717,7 +730,7 @@ local function handle_sc2(payload)
     if op == 'command' then
         local raw, req = normalize_command(m.raw or ''), m.req or ''
         local ok = false
-        if state.allowRemoteCommand and raw ~= '' then windower.send_command(raw); ok = true end
+        if state.allowRemoteCommand and raw ~= '' then ok = send_safe_command(raw) end
         windower.send_ipc_message(pack('SC2R', { op = 'ack', req = req, from = self_name(), status = ok and 'ok' or 'blocked' }))
         return
     end
@@ -780,9 +793,53 @@ end
 
 local function dispatch_command(raw)
     local req = start_pending('command', state.target, { raw = raw })
-    windower.send_command(raw)
+    if state.localEcho then send_safe_command(raw) end
     broadcast_v2('command', { raw = raw, req = req })
     msg(('Dispatch command req=%s target=%s'):format(req, state.target))
+end
+
+local function pending_summary_lines()
+    local lines = {}
+    for req, p in pairs(state.pending) do
+        local acked = 0
+        for _ in pairs(p.acks or {}) do acked = acked + 1 end
+        lines[#lines+1] = ('req=%s op=%s target=%s retries=%d acked=%d exhausted=%s'):format(req, tostring(p.op), tostring(p.target), tonumber(p.retries or 0), acked, tostring(p.exhausted))
+    end
+    table.sort(lines)
+    return lines
+end
+
+local function pending_list(limit)
+    local lines = pending_summary_lines()
+    if #lines == 0 then msg('No pending requests.') return end
+    local n = tonumber(limit) or #lines
+    for i = 1, math.min(n, #lines) do msg('  ' .. lines[i]) end
+end
+
+local function status_detail()
+    status_report()
+    local lines = pending_summary_lines()
+    if #lines == 0 then
+        msg('Pending detail: none')
+    else
+        msg(('Pending detail (%d):'):format(#lines))
+        for _, line in ipairs(lines) do msg('  ' .. line) end
+    end
+end
+
+local function roster_show(group)
+    local g = normalize(group or '')
+    if g == '' then msg('Usage: //conductor roster show <group>') return end
+    local members = state.rosters[g]
+    if not members then msg('Unknown group: ' .. g) return end
+    msg(('Roster %s (%d): %s'):format(g, #members, (#members > 0 and table.concat(members, ', ') or '(empty)')))
+end
+
+local function toggle_local_echo(flag)
+    local v = normalize(flag or '')
+    if v ~= 'on' and v ~= 'off' then msg('Usage: //conductor localecho on|off') return end
+    state.localEcho = (v == 'on')
+    msg('Local command echo set to ' .. tostring(state.localEcho))
 end
 
 -- init
@@ -802,7 +859,7 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1])
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: travel|command|follow|ping|target|roster|status|timeout|remotecmd|auto|mode|pause|rule|rules|events|trace|emit|version|clear')
+        msg('Commands: travel|command|follow|ping|target|roster|status|pending|timeout|remotecmd|auto|mode|pause|rule|rules|events|trace|emit|localecho|version|clear')
         return
     end
 
@@ -837,7 +894,8 @@ windower.register_event('addon command', function(...)
         local leader = join(args, ' ', 2)
         if leader == '' then msg('Usage: //conductor follow <leaderName>'); return end
         if not valid_name(leader) then msg('Invalid leader name format.'); return end
-        local follow_cmd = ('input /assist %s; wait 1; input /follow %s'):format(leader, leader)
+        local leader_arg = shell_escape_arg(leader)
+        local follow_cmd = ('input /assist %s; wait 1; input /follow %s'):format(leader_arg, leader_arg)
         dispatch_command(follow_cmd)
         msg(('Coordinated follow on %s'):format(leader))
         return
@@ -932,6 +990,11 @@ windower.register_event('addon command', function(...)
         return
     end
 
+    if cmd == 'localecho' then
+        toggle_local_echo(args[2])
+        return
+    end
+
     if cmd == 'trace' then
         local flag = normalize(args[2])
         if flag ~= 'on' and flag ~= 'off' then msg('Usage: //conductor trace on|off'); return end
@@ -949,7 +1012,12 @@ windower.register_event('addon command', function(...)
     end
 
     if cmd == 'status' then
-        status_report()
+        if normalize(args[2]) == 'detail' then status_detail() else status_report() end
+        return
+    end
+
+    if cmd == 'pending' then
+        pending_list(args[2])
         return
     end
 
@@ -957,8 +1025,9 @@ windower.register_event('addon command', function(...)
         local op = normalize(args[2])
         if op == 'add' then roster_add(args[3], args[4]); return end
         if op == 'remove' then roster_remove(args[3], args[4]); return end
+        if op == 'show' then roster_show(args[3]); return end
         if op == 'list' or op == '' then roster_list(); return end
-        msg('Usage: //conductor roster add|remove|list ...')
+        msg('Usage: //conductor roster add|remove|show|list ...')
         return
     end
 

--- a/addons/SessionConductor/sessionconductor.lua
+++ b/addons/SessionConductor/sessionconductor.lua
@@ -316,10 +316,21 @@ local function set_lockout(rule)
     state.lockouts[rule.lockout_group] = now() + math.max(1, dur)
 end
 
+local function check_rule_mode(rule)
+    local modes = rule.modes
+    if not modes then return true end
+    if type(modes) ~= 'table' then return true end
+    for _, m in ipairs(modes) do
+        if normalize(m) == normalize(state.mode) then return true end
+    end
+    return false
+end
+
 local function check_rule_event_match(rule, evt)
     local w = rule.when or {}
     if w.event and w.event ~= evt.type then return false end
     if not evaluate_where(evt, w.where) then return false end
+    if not check_rule_mode(rule) then return false end
     return true
 end
 
@@ -671,6 +682,11 @@ local function monitor_tick()
     end
 
     retry_pending()
+
+    local stale_cutoff = now() - 300
+    for req, p in pairs(state.pending) do
+        if p.sentAt < stale_cutoff then state.pending[req] = nil end
+    end
 end
 
 local function broadcast_v2(op, data)
@@ -690,7 +706,11 @@ local function handle_sc2(payload)
         local dest, req = m.dest or '', m.req or ''
         local ok = call_travel_router(dest)
         windower.send_ipc_message(pack('SC2R', { op = 'ack', req = req, from = self_name(), status = ok and 'ok' or 'fail' }))
-        emit_event('system.peer_unreachable', { req = req, peer = from, travel = dest, status = ok and 'ok' or 'fail' }, 'remote')
+        if ok then
+            emit_event('system.peer_travel_ok', { req = req, peer = from, destination = dest }, 'remote')
+        else
+            emit_event('system.peer_unreachable', { req = req, peer = from, destination = dest }, 'remote')
+        end
         return
     end
 
@@ -782,7 +802,20 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1])
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: travel|command|follow|ping|target|roster|status|timeout|remotecmd|auto|mode|pause|rule|rules|events|trace|emit')
+        msg('Commands: travel|command|follow|ping|target|roster|status|timeout|remotecmd|auto|mode|pause|rule|rules|events|trace|emit|version|clear')
+        return
+    end
+
+    if cmd == 'version' then
+        msg(('%s v%s by %s'):format(_addon.name, _addon.version, _addon.author))
+        return
+    end
+
+    if cmd == 'clear' then
+        local count = 0
+        for _ in pairs(state.pending) do count = count + 1 end
+        state.pending = {}
+        msg(('Cleared %d pending request(s).'):format(count))
         return
     end
 

--- a/addons/TravelRouter/README.md
+++ b/addons/TravelRouter/README.md
@@ -1,65 +1,39 @@
 # TravelRouter
 
-Content-aware travel routing addon for Windower.
+Content-aware travel planner and executor for Windower with persistent custom routes, explainable scoring, route introspection, and execution history.
 
 ## Install
 - Copy `addons/TravelRouter` into your Windower `addons/` directory.
 - Load with `//lua load TravelRouter`.
 
 ## What it does
-- Maps destination keywords to route candidates.
-- Scores candidates based on lightweight unlock/state signals.
-- Prints route rationale and selected step plan (`//troute plan <dest>`).
-- Executes selected route steps (`//troute run <dest>`).
-- Persists user-added route overrides across reloads/restarts.
-- Exposes IPC endpoints used by SessionConductor.
+- Plans travel using scored route candidates and unlock-aware selection.
+- Explains why a route was selected, including unlock/zone rationale.
+- Executes routes with chat, wait, and command steps.
+- Persists custom routes and player unlock state.
+- Records recent execution history for debugging and iteration.
+- Responds to SessionConductor IPC travel requests.
 
 ## Commands
-- `//troute list` — list known destinations
-- `//troute plan <destination>` — print best route + scoring rationale
-- `//troute run <destination>` — execute selected route
-- `//troute add <destination> <step1> ; <step2> ; ...` — persist user route override
-- `//troute reset <destination>` — remove user override for destination
-- `//troute unlock list` — list unlock tokens used for scoring
-- `//troute unlock add <token>` — mark unlock available (e.g. `hp`, `sg`, `warp`)
-- `//troute unlock remove <token>` — clear unlock token
-- `//troute save` — force-save user routes/state files
+- `//troute list` — list all known destinations
+- `//troute listuser` — list persisted custom route overrides
+- `//troute search <term>` — fuzzy-match destinations
+- `//troute plan <destination>` — print the selected plan
+- `//troute explain <destination>` — show all candidates and the winning rationale
+- `//troute dump <destination>` — dump candidate metadata and full step lists
+- `//troute run <destination>` — execute the selected plan
+- `//troute history [N]` — show recent route executions
+- `//troute add <dest> <step1> ; <step2> ; ...` — save a custom route
+- `//troute reset <dest>` — remove a persisted custom override
+- `//troute unlock list|add|remove <token>` — manage unlock hints used for scoring
+- `//troute save` — write user route/state files immediately
+- `//troute where` — print current zone id
+- `//troute version` — print addon version
 
-## Persistence files
-- `data/routes.user.lua` — user route overrides
-- `data/state.user.lua` — unlock/state tokens
+## Persistence
+- `data/routes.user.lua` — saved custom routes as structured route definitions
+- `data/state.user.lua` — unlock state and recent route execution history
 
-## Route data model
-`data/routes.lua` supports either:
-1) legacy simple route (list of steps), or
-2) candidate model:
-
-```lua
-jeuno = {
-  candidates = {
-    { name = 'home-point-direct', score = 15, requires = {'hp'}, steps = {...} },
-    { name = 'warp-fallback', score = 8, requires = {'warp'}, steps = {...} },
-  }
-}
-```
-
-## Route step format
-Each step is one of:
-- `say:<text>` — prints instruction text
-- `cmd:<windower command>` — executes command (leading `//` optional)
-
-## IPC
-### v2 (preferred, robust payload encoding)
-- request: `TR2|op=plan&dest=jeuno`
-- request: `TR2|op=run&dest=jeuno`
-- reply: `TR2R|op=plan&dest=jeuno&ok=1&steps=3&by=TravelRouter`
-- reply: `TR2R|op=run&dest=jeuno&ok=1&by=TravelRouter`
-
-### v1 (legacy compatibility)
-- `TRAVEL_ROUTER|plan|<destination>`
-- `TRAVEL_ROUTER|run|<destination>`
-- replies via `TRAVEL_ROUTER_REPLY|...`
-
-## Current behavior notes
-- Unlock/state signals are token-driven (`//troute unlock ...`) and can be extended.
-- Capability checks for third-party addon commands are not auto-detected yet.
+## Notes
+- Route selection stays bounded and explainable; it does not attempt hidden automation or unsafe inference.
+- Custom routes are stored as scored route objects so future metadata can be added cleanly.

--- a/addons/TravelRouter/data/routes.lua
+++ b/addons/TravelRouter/data/routes.lua
@@ -62,5 +62,302 @@ return {
         }
       }
     }
-  }
+  },
+
+  sandoria = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'say:Warp to Southern San d\'Oria via Home Point',
+          'cmd:hp San d\'Oria',
+          'say:Arrived in San d\'Oria'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 8,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp sandoria',
+          'say:Arrived in San d\'Oria'
+        }
+      }
+    }
+  },
+
+  bastok = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'say:Warp to Bastok Markets via Home Point',
+          'cmd:hp Bastok',
+          'say:Arrived in Bastok'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 8,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp bastok',
+          'say:Arrived in Bastok'
+        }
+      }
+    }
+  },
+
+  windurst = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'say:Warp to Windurst Woods via Home Point',
+          'cmd:hp Windurst',
+          'say:Arrived in Windurst'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 8,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp windurst',
+          'say:Arrived in Windurst'
+        }
+      }
+    }
+  },
+
+  selbina = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 14,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Selbina',
+          'say:Arrived in Selbina'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp selbina',
+          'say:Arrived in Selbina'
+        }
+      }
+    }
+  },
+
+  mhaura = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 14,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Mhaura',
+          'say:Arrived in Mhaura'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp mhaura',
+          'say:Arrived in Mhaura'
+        }
+      }
+    }
+  },
+
+  kazham = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 14,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Kazham',
+          'say:Arrived in Kazham'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp kazham',
+          'say:Arrived in Kazham'
+        }
+      }
+    }
+  },
+
+  rabao = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 14,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Rabao',
+          'say:Arrived in Rabao'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp rabao',
+          'say:Arrived in Rabao'
+        }
+      }
+    }
+  },
+
+  aht_urhgan = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'say:Warp to Aht Urhgan Whitegate via Home Point',
+          'cmd:hp Aht Urhgan Whitegate',
+          'say:Arrived in Whitegate'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 8,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp whitegate',
+          'say:Arrived in Whitegate'
+        }
+      }
+    }
+  },
+
+  nashmau = {
+    candidates = {
+      {
+        name = 'survival-guide',
+        score = 13,
+        requires = {'sg'},
+        steps = {
+          'cmd:sg Nashmau',
+          'say:Arrived in Nashmau'
+        }
+      }
+    }
+  },
+
+  tavnazia = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 15,
+        requires = {'hp'},
+        steps = {
+          'cmd:hp Tavnazian Safehold',
+          'say:Arrived in Tavnazian Safehold'
+        }
+      },
+      {
+        name = 'warp-fallback',
+        score = 7,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp tavnazia',
+          'say:Arrived in Tavnazian Safehold'
+        }
+      }
+    }
+  },
+
+  escha_zitah = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 14,
+        requires = {'hp'},
+        steps = {
+          'cmd:hp Escha - Zi\'Tah',
+          'say:Arrived in Escha Zi\'Tah'
+        }
+      }
+    }
+  },
+
+  escha_ruaun = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 14,
+        requires = {'hp'},
+        steps = {
+          'cmd:hp Escha - Ru\'Aun',
+          'say:Arrived in Escha Ru\'Aun'
+        }
+      }
+    }
+  },
+
+  reisenjima = {
+    candidates = {
+      {
+        name = 'home-point',
+        score = 14,
+        requires = {'hp'},
+        steps = {
+          'cmd:hp Reisenjima',
+          'say:Arrived in Reisenjima'
+        }
+      }
+    }
+  },
+
+  abyssea_la_theine = {
+    candidates = {
+      {
+        name = 'waypoint',
+        score = 12,
+        requires = {'warp'},
+        steps = {
+          'cmd:warp abyssea_la_theine',
+          'say:Arrived in Abyssea - La Theine'
+        }
+      }
+    }
+  },
+
+  dynamis_san_doria = {
+    candidates = {
+      {
+        name = 'warp-entry',
+        score = 10,
+        requires = {'warp'},
+        steps = {
+          'say:Travel to San d\'Oria first, then enter Dynamis',
+          'cmd:warp sandoria',
+          'wait:3',
+          'say:Proceed to Trail Markings for Dynamis entry'
+        }
+      }
+    }
+  },
 }

--- a/addons/TravelRouter/travelrouter.lua
+++ b/addons/TravelRouter/travelrouter.lua
@@ -1,6 +1,6 @@
 _addon.name = 'TravelRouter'
 _addon.author = 'boostie'
-_addon.version = '0.2.0'
+_addon.version = '0.3.0'
 _addon.commands = {'troute', 'travelrouter'}
 _addon.description = 'Content-aware travel route planner/executor with persistence and v2 IPC.'
 
@@ -11,7 +11,7 @@ local USER_STATE_FILE = (windower.addon_path or '') .. 'data/state.user.lua'
 
 local routes = {}
 local user_routes = {}
-local state = { unlocks = { hp = true, sg = true, warp = true } }
+local state = { unlocks = { hp = true, sg = true, warp = true }, history = {} }
 
 local function msg(text)
     windower.add_to_chat(207, ('[TravelRouter] %s'):format(text))
@@ -70,15 +70,32 @@ local function write_table_file(path, t)
     return true
 end
 
+local function canonicalize_route(def)
+    if type(def) ~= 'table' then return nil end
+    if def.steps then
+        local out = copy_table(def)
+        out.name = out.name or 'custom'
+        if out.score == nil then out.score = 25 end
+        return out
+    end
+    if def[1] and type(def[1]) == 'string' then
+        return { name = 'custom', score = 25, steps = copy_table(def), source = 'user' }
+    end
+    return copy_table(def)
+end
+
 local function merge_routes()
     routes = copy_table(base_routes)
-    for dest, route in pairs(user_routes) do routes[dest] = route end
+    for dest, route in pairs(user_routes) do
+        routes[dest] = canonicalize_route(route) or route
+    end
 end
 
 local function load_user_files()
     user_routes = safe_load(USER_ROUTE_FILE) or {}
     state = safe_load(USER_STATE_FILE) or state
     if type(state.unlocks) ~= 'table' then state.unlocks = {} end
+    if type(state.history) ~= 'table' then state.history = {} end
     merge_routes()
 end
 
@@ -132,6 +149,37 @@ local function score_candidate(c)
     return score, reasons
 end
 
+local function route_step_count(route_key)
+    local candidates = route_candidates(route_key)
+    if not candidates then return 0 end
+    local best = 0
+    for _, c in ipairs(candidates) do
+        local n = #(c.steps or {})
+        if n > best then best = n end
+    end
+    return best
+end
+
+local function describe_candidate(c)
+    local bits = {}
+    if c.name then bits[#bits+1] = ('name=%s'):format(c.name) end
+    if c.score ~= nil then bits[#bits+1] = ('base=%s'):format(tostring(c.score)) end
+    if c.requires and #c.requires > 0 then bits[#bits+1] = ('requires=%s'):format(table.concat(c.requires, ',')) end
+    if c.preferred_zone then bits[#bits+1] = ('preferred_zone=%s'):format(tostring(c.preferred_zone)) end
+    bits[#bits+1] = ('steps=%d'):format(#(c.steps or {}))
+    return table.concat(bits, ' | ')
+end
+
+local function trim_history(limit)
+    while #state.history > (limit or 20) do table.remove(state.history, 1) end
+end
+
+local function record_history(entry)
+    state.history[#state.history+1] = entry
+    trim_history(20)
+    save_user_state()
+end
+
 local function pick_plan(dest)
     local key = fuzzy_match_dest(dest)
     if not key then return nil, nil end
@@ -154,12 +202,14 @@ local function list_destinations()
 end
 
 local function print_plan(dest)
+    local requested = dest
+    local key = fuzzy_match_dest(dest)
     local plan, meta = pick_plan(dest)
     if not plan then
         msg(('No route for "%s". Use //troute list or //troute add ...'):format(dest or ''))
         return false, nil
     end
-    msg(('Route plan for "%s" via "%s" (score %d):'):format(dest, plan.name or 'default', meta.score or 0))
+    msg(('Route plan for "%s" via "%s" (score %d):'):format(key or requested or '', plan.name or 'default', meta.score or 0))
     if meta.reasons and #meta.reasons > 0 then msg('  rationale: ' .. table.concat(meta.reasons, ', ')) end
     for i, step in ipairs(plan.steps or {}) do msg(('  %d) %s'):format(i, step)) end
     return true, plan
@@ -189,10 +239,12 @@ local function execute_step(step)
 end
 
 local function run_plan(dest)
-    local plan = pick_plan(dest)
+    local key = fuzzy_match_dest(dest)
+    local plan, meta = pick_plan(dest)
     if not plan then msg(('No route for "%s".'):format(dest or '')); return false end
-    msg(('Executing route "%s" (%s)...'):format(dest, plan.name or 'default'))
+    msg(('Executing route "%s" (%s, score %d)...'):format(key or dest or '', plan.name or 'default', (meta and meta.score) or 0))
     for _, step in ipairs(plan.steps or {}) do execute_step(step) end
+    record_history({ ts = os.time(), dest = key or dest, plan = plan.name or 'default', score = (meta and meta.score) or 0, steps = #(plan.steps or {}) })
     return true
 end
 
@@ -205,10 +257,66 @@ local function add_route(dest, payload)
         if step ~= '' then steps[#steps+1] = step end
     end
     if #steps == 0 then msg('No steps parsed. Example: //troute add jeuno say:go ; cmd:hp #1'); return end
-    user_routes[key] = steps
+    user_routes[key] = { name = 'custom', score = 25, steps = steps, source = 'user' }
     merge_routes()
     save_user_routes()
     msg(('Route "%s" saved with %d steps.'):format(key, #steps))
+end
+
+local function list_user_routes()
+    local keys = {}
+    for k, _ in pairs(user_routes) do keys[#keys+1] = k end
+    table.sort(keys)
+    if #keys == 0 then msg('No user routes saved.') return end
+    for _, key in ipairs(keys) do
+        local route = canonicalize_route(user_routes[key]) or {}
+        msg(('user route %s: %d step(s) via %s'):format(key, #(route.steps or {}), route.name or 'custom'))
+    end
+end
+
+local function explain_route(dest)
+    local key = fuzzy_match_dest(dest)
+    local route = key and routes[key] or nil
+    local candidates = key and route_candidates(key) or nil
+    if not key or not route or not candidates then
+        msg(('No route for "%s".'):format(dest or ''))
+        return
+    end
+    msg(('Route explain for "%s": %d candidate(s)'):format(key, #candidates))
+    local best, meta = pick_plan(key)
+    for i, c in ipairs(candidates) do
+        local score, reasons = score_candidate(c)
+        local chosen = (best == c) and ' [selected]' or ''
+        msg(('  %d) score=%d%s %s'):format(i, score, chosen, describe_candidate(c)))
+        if reasons and #reasons > 0 then msg('     rationale: ' .. table.concat(reasons, ', ')) end
+    end
+    if meta and meta.reasons and #meta.reasons > 0 then
+        msg('Winning rationale: ' .. table.concat(meta.reasons, ', '))
+    end
+end
+
+local function history_cmd(limit)
+    local n = tonumber(limit) or 5
+    if #state.history == 0 then msg('No route execution history yet.') return end
+    local start_idx = math.max(1, #state.history - n + 1)
+    for i = start_idx, #state.history do
+        local h = state.history[i]
+        msg(('%s | dest=%s plan=%s score=%s steps=%s'):format(os.date('%Y-%m-%d %H:%M:%S', h.ts or os.time()), tostring(h.dest or '?'), tostring(h.plan or '?'), tostring(h.score or '?'), tostring(h.steps or '?')))
+    end
+end
+
+local function dump_route(dest)
+    local key = fuzzy_match_dest(dest)
+    local route = key and routes[key] or nil
+    if not key or not route then msg(('No route for "%s".'):format(dest or '')) return end
+    local candidates = route_candidates(key) or {}
+    msg(('Route dump for "%s": %d candidate(s), up to %d step(s)'):format(key, #candidates, route_step_count(key)))
+    for i, c in ipairs(candidates) do
+        msg(('  candidate %d: %s'):format(i, describe_candidate(c)))
+        for step_idx, step in ipairs(c.steps or {}) do
+            msg(('    %d.%d %s'):format(i, step_idx, step))
+        end
+    end
 end
 
 local function reset_route(dest)
@@ -300,7 +408,7 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1])
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: list | plan <dest> | run <dest> | add <dest> <s1>;... | reset <dest> | unlock list|add|remove <k> | save | where | search <term> | version')
+        msg('Commands: list | listuser | search <term> | plan <dest> | explain <dest> | dump <dest> | run <dest> | history [N] | add <dest> <s1>;... | reset <dest> | unlock list|add|remove <k> | save | where | version')
         return
     end
 
@@ -314,6 +422,8 @@ windower.register_event('addon command', function(...)
         msg(('Current zone: %s'):format(tostring(info.zone or 'unknown')))
         return
     end
+
+    if cmd == 'listuser' then list_user_routes(); return end
 
     if cmd == 'search' then
         local term = normalize(join(args, ' ', 2))
@@ -332,7 +442,10 @@ windower.register_event('addon command', function(...)
     end
     if cmd == 'list' then list_destinations(); return end
     if cmd == 'plan' then print_plan(join(args, ' ', 2)); return end
+    if cmd == 'explain' then explain_route(join(args, ' ', 2)); return end
+    if cmd == 'dump' then dump_route(join(args, ' ', 2)); return end
     if cmd == 'run' then run_plan(join(args, ' ', 2)); return end
+    if cmd == 'history' then history_cmd(args[2]); return end
     if cmd == 'add' then add_route(args[2], join(args, ' ', 3)); return end
     if cmd == 'reset' then reset_route(join(args, ' ', 2)); return end
     if cmd == 'save' then save_user_routes(); save_user_state(); return end

--- a/addons/TravelRouter/travelrouter.lua
+++ b/addons/TravelRouter/travelrouter.lua
@@ -92,6 +92,18 @@ local function save_user_state()
     msg(ok and ('Saved state to %s'):format(USER_STATE_FILE) or 'Failed to save state file.')
 end
 
+local function fuzzy_match_dest(dest)
+    local key = normalize(dest)
+    if routes[key] then return key end
+    for k, _ in pairs(routes) do
+        if k:find(key, 1, true) then return k end
+    end
+    for k, _ in pairs(routes) do
+        if key:find(k, 1, true) then return k end
+    end
+    return nil
+end
+
 local function route_candidates(dest)
     local route = routes[dest]
     if not route then return nil end
@@ -121,7 +133,8 @@ local function score_candidate(c)
 end
 
 local function pick_plan(dest)
-    local key = normalize(dest)
+    local key = fuzzy_match_dest(dest)
+    if not key then return nil, nil end
     local candidates = route_candidates(key)
     if not candidates then return nil, nil end
 
@@ -287,7 +300,34 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1])
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: list | plan <dest> | run <dest> | add <dest> <s1>;... | reset <dest> | unlock list|add|remove <k> | save')
+        msg('Commands: list | plan <dest> | run <dest> | add <dest> <s1>;... | reset <dest> | unlock list|add|remove <k> | save | where | search <term> | version')
+        return
+    end
+
+    if cmd == 'version' then
+        msg(('%s v%s by %s'):format(_addon.name, _addon.version, _addon.author))
+        return
+    end
+
+    if cmd == 'where' then
+        local info = windower.ffxi.get_info() or {}
+        msg(('Current zone: %s'):format(tostring(info.zone or 'unknown')))
+        return
+    end
+
+    if cmd == 'search' then
+        local term = normalize(join(args, ' ', 2))
+        if term == '' then msg('Usage: //troute search <term>'); return end
+        local matches = {}
+        for k, _ in pairs(routes) do
+            if k:find(term, 1, true) then matches[#matches+1] = k end
+        end
+        table.sort(matches)
+        if #matches > 0 then
+            msg(('Matching destinations (%d): %s'):format(#matches, table.concat(matches, ', ')))
+        else
+            msg(('No destinations matching "%s"'):format(term))
+        end
         return
     end
     if cmd == 'list' then list_destinations(); return end

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,10 +13,11 @@
 - [ ] Add confidence score for inferred categories
 
 ## Phase 3 (productize)
-- [ ] Publish static searchable site
+- [x] Publish static searchable site
 - [ ] Add tags and faceted filters (category, activity, popularity)
 - [ ] Add "starter addon ideas" page with implementation complexity
-- [ ] Ship first addon concept spec (`AddonHealth` or `OnboardingPilot`)
+- [x] Ship first addon concept spec (`AddonHealth`)
+- [x] Build AddonHealth v0.1 addon
 
 ## Contribution guidelines (draft)
 - Use PRs for repo additions/corrections

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,3 +23,11 @@
 - Use PRs for repo additions/corrections
 - Include source links for metadata edits
 - Prefer reproducible scripts over manual edits
+
+
+## Near-term implementation priorities
+
+- Expand TravelRouter route explainability so route choice stays debuggable instead of magical.
+- Make SessionConductor operator-facing status richer so ACK/retry state is visible in game.
+- Keep AddonHealth lightweight, but improve signal quality with severity grading and short-session report history.
+- Continue preferring bounded, inspectable automation over opaque one-shot scripts.

--- a/index.html
+++ b/index.html
@@ -10,39 +10,47 @@
     h1 { margin-bottom: .2rem; }
     .muted { color:#9fb0ff; margin-top:0; }
     input, select { padding:.6rem .7rem; border-radius:.5rem; border:1px solid #2b3666; background:#131a33; color:#e8ecff; }
-    .controls { display:flex; gap:.75rem; flex-wrap:wrap; margin:1rem 0 1.25rem; }
+    input:focus, select:focus { outline: 2px solid #5b8def; border-color: #5b8def; }
+    .controls { display:flex; gap:.75rem; flex-wrap:wrap; margin:1rem 0 .5rem; align-items: center; }
+    .result-count { color:#9fb0ff; font-size:.88rem; margin: 0 0 1rem; }
     table { width:100%; border-collapse: collapse; background:#0f1530; border:1px solid #27305c; }
     th, td { text-align:left; padding:.55rem .6rem; border-bottom:1px solid #1e2750; font-size:.92rem; vertical-align:top; }
-    th { position:sticky; top:0; background:#131a33; }
+    th { position:sticky; top:0; background:#131a33; cursor:pointer; user-select:none; white-space: nowrap; }
+    th:hover { background:#1a2448; }
+    th .sort-arrow { font-size:.7rem; margin-left:.3rem; opacity:.5; }
+    th .sort-arrow.active { opacity:1; }
     a { color:#8fc6ff; text-decoration:none; }
     a:hover { text-decoration:underline; }
     .tag { background:#1f2b58; border:1px solid #334179; padding:.1rem .4rem; border-radius:.4rem; font-size:.78rem; display:inline-block; }
+    .no-results { text-align:center; padding:2rem; color:#9fb0ff; }
+    tr:hover td { background:#151d3a; }
   </style>
 </head>
 <body>
   <h1>FFXI Addon Landscape</h1>
-  <p class="muted">Searchable index of FFXI addons across GitHub repos.</p>
+  <p class="muted">Searchable index of FFXI addons across GitHub repos. <a href="https://github.com/MrBoostie/ffxi-addon-landscape">View on GitHub</a></p>
 
   <div class="controls">
-    <input id="q" placeholder="Search addon/repo/category..." size="36" />
-    <select id="cat"><option value="">All categories</option></select>
-    <select id="minFresh">
+    <input id="q" placeholder="Search addon/repo/category..." size="36" aria-label="Search addons" />
+    <select id="cat" aria-label="Filter by category"><option value="">All categories</option></select>
+    <select id="minFresh" aria-label="Filter by freshness">
       <option value="0">Any freshness</option>
       <option value="5">Freshness 5 (≤6mo)</option>
       <option value="4">Freshness 4+ (≤1y)</option>
       <option value="3">Freshness 3+ (≤2y)</option>
     </select>
   </div>
+  <p class="result-count" id="count"></p>
 
-  <table>
+  <table role="grid">
     <thead>
       <tr>
-        <th>Addon</th>
+        <th data-sort="addon_name">Addon <span class="sort-arrow" id="sort-addon_name"></span></th>
         <th>Description</th>
-        <th>Category</th>
-        <th>Repos</th>
-        <th>Freshness</th>
-        <th>Score</th>
+        <th data-sort="category">Category <span class="sort-arrow" id="sort-category"></span></th>
+        <th data-sort="repo_count">Repos <span class="sort-arrow" id="sort-repo_count"></span></th>
+        <th data-sort="freshness_max">Freshness <span class="sort-arrow" id="sort-freshness_max"></span></th>
+        <th data-sort="opportunity_score">Score <span class="sort-arrow" id="sort-opportunity_score"></span></th>
       </tr>
     </thead>
     <tbody id="rows"></tbody>
@@ -50,31 +58,69 @@
 
 <script>
 let DATA=[];
+let sortKey='opportunity_score', sortDir=-1;
 const q=document.getElementById('q');
 const cat=document.getElementById('cat');
 const minFresh=document.getElementById('minFresh');
 const rows=document.getElementById('rows');
+const countEl=document.getElementById('count');
+
+function escapeHtml(s) {
+  const d = document.createElement('div');
+  d.textContent = s || '';
+  return d.innerHTML;
+}
 
 function render(){
   const needle=(q.value||'').toLowerCase().trim();
   const c=cat.value;
   const mf=Number(minFresh.value||0);
-  const filtered=DATA.filter(a=>{
+  let filtered=DATA.filter(a=>{
     if(c && a.category!==c) return false;
     if(a.freshness_max < mf) return false;
     if(!needle) return true;
     const blob=[a.addon_name,a.description||'',a.category,...a.repos].join(' ').toLowerCase();
     return blob.includes(needle);
   });
+
+  filtered.sort((a,b)=>{
+    let va=a[sortKey], vb=b[sortKey];
+    if(typeof va==='string') va=va.toLowerCase();
+    if(typeof vb==='string') vb=vb.toLowerCase();
+    if(va<vb) return -1*sortDir;
+    if(va>vb) return 1*sortDir;
+    return 0;
+  });
+
+  countEl.textContent=`Showing ${Math.min(filtered.length,500)} of ${filtered.length} addon${filtered.length===1?'':'s'} (${DATA.length} total)`;
+
+  document.querySelectorAll('.sort-arrow').forEach(el=>{el.textContent='';el.classList.remove('active');});
+  const arrow=document.getElementById('sort-'+sortKey);
+  if(arrow){arrow.textContent=sortDir>0?'\u25B2':'\u25BC';arrow.classList.add('active');}
+
+  if(filtered.length===0){
+    rows.innerHTML='<tr><td colspan="6" class="no-results">No addons match your filters.</td></tr>';
+    return;
+  }
+
   rows.innerHTML=filtered.slice(0,500).map(a=>`<tr>
-    <td><strong>${a.addon_name}</strong><br><span class="muted">${a.addon_key}</span></td>
-    <td>${a.description || '<span class="muted">No description yet</span>'}<br>${a.description_source && a.description_source !== 'heuristic' ? `<a class="muted" href="${a.description_source}" target="_blank" rel="noreferrer">source</a>` : `<span class="muted">source: heuristic</span>`}</td>
-    <td><span class="tag">${a.category}</span></td>
-    <td>${a.repos.map(r=>`<div><a href="https://github.com/${r}" target="_blank" rel="noreferrer">${r}</a></div>`).join('')}</td>
+    <td><strong>${escapeHtml(a.addon_name)}</strong><br><span class="muted">${escapeHtml(a.addon_key)}</span></td>
+    <td>${escapeHtml(a.description) || '<span class="muted">No description yet</span>'}<br>${a.description_source && a.description_source !== 'heuristic' ? `<a class="muted" href="${escapeHtml(a.description_source)}" target="_blank" rel="noreferrer">source</a>` : `<span class="muted">source: heuristic</span>`}</td>
+    <td><span class="tag">${escapeHtml(a.category)}</span></td>
+    <td>${(a.repos||[]).map(r=>`<div><a href="https://github.com/${escapeHtml(r)}" target="_blank" rel="noreferrer">${escapeHtml(r)}</a></div>`).join('')}</td>
     <td>${a.freshness_max}</td>
     <td>${a.opportunity_score}</td>
   </tr>`).join('');
 }
+
+document.querySelectorAll('th[data-sort]').forEach(th=>{
+  th.addEventListener('click',()=>{
+    const key=th.dataset.sort;
+    if(sortKey===key) sortDir*=-1;
+    else { sortKey=key; sortDir=-1; }
+    render();
+  });
+});
 
 fetch('./ffxi-addon-catalog-normalized.json').then(r=>r.json()).then(d=>{
   DATA=d;

--- a/lib/common.lua
+++ b/lib/common.lua
@@ -1,0 +1,85 @@
+local common = {}
+
+function common.normalize(s)
+    return (s or ''):lower():gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+function common.join(tbl, sep, start_idx)
+    local s = {}
+    for i = start_idx or 1, #tbl do s[#s+1] = tbl[i] end
+    return table.concat(s, sep or ' ')
+end
+
+function common.serialize_value(v, indent)
+    indent = indent or ''
+    if type(v) == 'string' then return string.format('%q', v) end
+    if type(v) == 'number' or type(v) == 'boolean' then return tostring(v) end
+    if type(v) == 'table' then
+        local n = indent .. '  '
+        local lines = {'{'}
+        for k, vv in pairs(v) do
+            local key = (type(k) == 'string' and k:match('^[%a_][%w_]*$')) and k or ('[' .. common.serialize_value(k) .. ']')
+            lines[#lines+1] = n .. key .. ' = ' .. common.serialize_value(vv, n) .. ','
+        end
+        lines[#lines+1] = indent .. '}'
+        return table.concat(lines, '\n')
+    end
+    return 'nil'
+end
+
+function common.write_table_file(path, t)
+    local f = io.open(path, 'w')
+    if not f then return false end
+    f:write('return ', common.serialize_value(t), '\n')
+    f:close()
+    return true
+end
+
+function common.load_table(path)
+    local ok, t = pcall(dofile, path)
+    if ok and type(t) == 'table' then return t end
+    return nil
+end
+
+function common.enc(s)
+    return tostring(s or ''):gsub('([^%w%-_%.~ ])', function(c) return string.format('%%%02X', string.byte(c)) end):gsub(' ', '+')
+end
+
+function common.dec(s)
+    s = (s or ''):gsub('+', ' ')
+    return s:gsub('%%(%x%x)', function(h) return string.char(tonumber(h, 16)) end)
+end
+
+function common.pack(prefix, t)
+    local parts = {}
+    for k, v in pairs(t or {}) do parts[#parts+1] = common.enc(k) .. '=' .. common.enc(v) end
+    return prefix .. '|' .. table.concat(parts, '&')
+end
+
+function common.unpack_payload(s)
+    local out = {}
+    for pair in (s or ''):gmatch('([^&]+)') do
+        local k, v = pair:match('([^=]+)=(.*)')
+        if k then out[common.dec(k)] = common.dec(v or '') end
+    end
+    return out
+end
+
+function common.copy_table(t)
+    local out = {}
+    for k, v in pairs(t or {}) do
+        if type(v) == 'table' then out[k] = common.copy_table(v) else out[k] = v end
+    end
+    return out
+end
+
+function common.self_name()
+    local p = windower.ffxi.get_player()
+    return (p and p.name) or 'unknown'
+end
+
+function common.now()
+    return os.time()
+end
+
+return common

--- a/prototypes/addonhealth/README.md
+++ b/prototypes/addonhealth/README.md
@@ -1,13 +1,5 @@
 # AddonHealth Prototype Scaffold
 
-This folder is a placeholder scaffold for the first implementation pass.
+This folder was the original placeholder scaffold.
 
-Planned structure:
-
-- `init.lua` — addon entrypoint
-- `commands.lua` — command routing (`//addonhealth ...`)
-- `checks/` — individual health checks
-- `render.lua` — HUD text rendering
-- `data/` — local snapshots/reports
-
-Status: scaffold only (no runtime code committed yet).
+The v0.1 implementation now lives at `addons/AddonHealth/`. See `specs/addonhealth-v0.1.md` for the spec and `addons/AddonHealth/README.md` for usage.


### PR DESCRIPTION
## Summary
This is a substantial quality pass across the three shipped addons, focused on making the project more inspectable, operator-friendly, and coherent with its stated philosophy of bounded, explainable automation.

### TravelRouter
- adds route explainability commands (`explain`, `dump`)
- persists custom routes as structured route definitions instead of raw step arrays
- records recent route execution history in user state
- adds `listuser` and `history` commands for better day-to-day operator introspection
- upgrades README to document the richer command surface

### SessionConductor
- adds pending-request inspection (`pending`, `status detail`)
- adds `roster show <group>` for fast scope inspection
- adds `localecho on|off` so local command execution can be disabled while still broadcasting
- hardens follow command construction by quoting the leader argument before injecting it into command strings
- refreshes README to better describe the operational model

### AddonHealth
- adds severity grading (`ok`, `warn`, `alert`)
- adds compact `summary` output
- keeps a short in-memory history of recent reports with a `history` command
- refreshes README to document the improved diagnostics workflow

### Docs
- updates root README smoke test to highlight introspection-focused commands
- adds a near-term implementation priorities section to the roadmap

## Validation
- verified all intended command/function additions landed in the modified Lua files
- ran basic textual validation against the three addon entrypoints after edits

## Notes
- intentionally did not include local untracked study artifacts (`ODIN_PROJECT_NOTES.md`, `repo_scan.txt`)
- this PR stays within the repo's current design direction rather than bolting on opaque automation
