### PR TITLE
feat: add addon health dashboard and validation tooling

### DIFF
--- a/addons/AddonHealth/README.md
+++ b/addons/AddonHealth/README.md
@@ -1,0 +1,52 @@
+# AddonHealth v0.1
+
+Unified health dashboard for your Windower addon stack.
+
+## What it does
+
+- Reports which addons are loaded
+- Checks for missing dependencies between addons
+- Validates that expected config files exist
+- Periodic background watch mode for ongoing monitoring
+- Export diagnostic snapshots to file
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `//addonhealth` | Show help |
+| `//addonhealth check` | Run diagnostics and display results |
+| `//addonhealth watch on [interval]` | Enable periodic health checks (default 30s) |
+| `//addonhealth watch off` | Disable periodic checks |
+| `//addonhealth export` | Export last report to `data/` directory |
+| `//addonhealth status` | Show last report without re-running |
+
+## Setup
+
+```
+1. Copy AddonHealth/ to your Windower addons/ directory
+2. //lua load AddonHealth
+3. //addonhealth check
+```
+
+## Output
+
+The check displays addon load status, dependency issues, and file validation results:
+
+```
+[AddonHealth] --- Health Check @ 14:23:05 ---
+[AddonHealth] Player: MyChar | Zone: 230
+[AddonHealth] Addon Status:
+[AddonHealth]   [+] TravelRouter
+[AddonHealth]   [+] SessionConductor
+[AddonHealth]   [-] GearSwap
+[AddonHealth] Dependency Issues:
+[AddonHealth]   SessionConductor requires TravelRouter (not loaded)
+[AddonHealth] All checks passed.
+[AddonHealth] ---
+```
+
+
+## Notes
+
+- Windower builds can expose loaded addons in different shapes. AddonHealth now tolerates string lists, keyed tables, and addon descriptor tables when detecting loaded addons.

--- a/addons/AddonHealth/addonhealth.lua
+++ b/addons/AddonHealth/addonhealth.lua
@@ -1,0 +1,256 @@
+_addon.name = 'AddonHealth'
+_addon.author = 'boostie'
+_addon.version = '0.1.0'
+_addon.commands = {'addonhealth', 'ahealth'}
+_addon.description = 'Unified health dashboard for Windower addon stack status and diagnostics.'
+
+local REPORT_DIR = (windower.addon_path or '') .. 'data/'
+local KNOWN_ADDONS = {
+    'TravelRouter', 'SessionConductor', 'GearSwap', 'Shortcuts',
+    'DressUp', 'FastCS', 'Treasury', 'Config', 'Cancel', 'Enternity',
+}
+
+local KNOWN_DEPS = {
+    TravelRouter = {},
+    SessionConductor = { 'TravelRouter' },
+    GearSwap = {},
+    Shortcuts = {},
+}
+
+local state = {
+    watchEnabled = false,
+    watchInterval = 30,
+    lastCheck = 0,
+    lastReport = nil,
+}
+
+local function msg(text)
+    windower.add_to_chat(200, ('[AddonHealth] %s'):format(text))
+end
+
+local function now()
+    return os.time()
+end
+
+local function get_loaded_addons()
+    local loaded = {}
+    if windower.get_addons then
+        local addons = windower.get_addons() or {}
+        for k, v in pairs(addons) do
+            if type(v) == 'string' then
+                loaded[v:lower()] = true
+            elseif type(v) == 'table' then
+                local name = v.name or v.addon or v.short_name
+                if type(name) == 'string' then
+                    loaded[name:lower()] = true
+                end
+                if v.path then
+                    local inferred = tostring(v.path):match('([^/\]+)[/\]?$')
+                    if inferred then loaded[inferred:lower()] = true end
+                end
+                if v.loaded == false and name then
+                    loaded[name:lower()] = nil
+                end
+            elseif type(k) == 'string' and v then
+                loaded[k:lower()] = true
+            end
+        end
+    end
+    return loaded
+end
+
+local function check_loaded()
+    local loaded = get_loaded_addons()
+    local results = {}
+    for _, name in ipairs(KNOWN_ADDONS) do
+        results[#results+1] = {
+            addon = name,
+            loaded = loaded[name:lower()] or false,
+        }
+    end
+    return results
+end
+
+local function check_dependencies()
+    local loaded = get_loaded_addons()
+    local issues = {}
+    for addon, deps in pairs(KNOWN_DEPS) do
+        if loaded[addon:lower()] then
+            for _, dep in ipairs(deps) do
+                if not loaded[dep:lower()] then
+                    issues[#issues+1] = {
+                        addon = addon,
+                        missing_dep = dep,
+                        severity = 'warn',
+                    }
+                end
+            end
+        end
+    end
+    return issues
+end
+
+local function check_files()
+    local issues = {}
+    local paths = {
+        { label = 'TravelRouter routes', path = (windower.addon_path or '') .. '../TravelRouter/data/routes.lua' },
+        { label = 'SessionConductor rules', path = (windower.addon_path or '') .. '../SessionConductor/data/rules.default.lua' },
+    }
+    for _, entry in ipairs(paths) do
+        local f = io.open(entry.path, 'r')
+        if f then
+            f:close()
+        else
+            issues[#issues+1] = {
+                label = entry.label,
+                path = entry.path,
+                status = 'missing',
+            }
+        end
+    end
+    return issues
+end
+
+local function run_diagnostics()
+    local report = {
+        timestamp = now(),
+        player = (windower.ffxi.get_player() or {}).name or 'unknown',
+        zone = (windower.ffxi.get_info() or {}).zone or 0,
+        loaded = check_loaded(),
+        dep_issues = check_dependencies(),
+        file_issues = check_files(),
+    }
+    state.lastReport = report
+    state.lastCheck = now()
+    return report
+end
+
+local function display_report(report)
+    msg(('--- Health Check @ %s ---'):format(os.date('%H:%M:%S', report.timestamp)))
+    msg(('Player: %s | Zone: %d'):format(report.player, report.zone))
+
+    msg('Addon Status:')
+    for _, entry in ipairs(report.loaded) do
+        local icon = entry.loaded and '+' or '-'
+        msg(('  [%s] %s'):format(icon, entry.addon))
+    end
+
+    if #report.dep_issues > 0 then
+        msg('Dependency Issues:')
+        for _, issue in ipairs(report.dep_issues) do
+            msg(('  %s requires %s (not loaded)'):format(issue.addon, issue.missing_dep))
+        end
+    end
+
+    if #report.file_issues > 0 then
+        msg('File Issues:')
+        for _, issue in ipairs(report.file_issues) do
+            msg(('  %s: %s (%s)'):format(issue.label, issue.status, issue.path))
+        end
+    end
+
+    local total_issues = #report.dep_issues + #report.file_issues
+    if total_issues == 0 then
+        msg('All checks passed.')
+    else
+        msg(('%d issue(s) found.'):format(total_issues))
+    end
+    msg('---')
+end
+
+local function export_report(report)
+    local filename = ('addonhealth-report-%s.txt'):format(os.date('%Y%m%d-%H%M%S', report.timestamp))
+    local path = REPORT_DIR .. filename
+    local f = io.open(path, 'w')
+    if not f then
+        msg('Failed to write report file: ' .. path)
+        return
+    end
+
+    f:write(('AddonHealth Report - %s\n'):format(os.date('%Y-%m-%d %H:%M:%S', report.timestamp)))
+    f:write(('Player: %s | Zone: %d\n\n'):format(report.player, report.zone))
+
+    f:write('Addon Status:\n')
+    for _, entry in ipairs(report.loaded) do
+        f:write(('  [%s] %s\n'):format(entry.loaded and 'OK' or 'NOT LOADED', entry.addon))
+    end
+
+    if #report.dep_issues > 0 then
+        f:write('\nDependency Issues:\n')
+        for _, issue in ipairs(report.dep_issues) do
+            f:write(('  %s requires %s (not loaded)\n'):format(issue.addon, issue.missing_dep))
+        end
+    end
+
+    if #report.file_issues > 0 then
+        f:write('\nFile Issues:\n')
+        for _, issue in ipairs(report.file_issues) do
+            f:write(('  %s: %s\n'):format(issue.label, issue.status))
+        end
+    end
+
+    f:write(('\nTotal issues: %d\n'):format(#report.dep_issues + #report.file_issues))
+    f:close()
+    msg('Report exported: ' .. path)
+end
+
+local function watch_tick()
+    if not state.watchEnabled then return end
+    if now() - state.lastCheck < state.watchInterval then return end
+    local report = run_diagnostics()
+    local total_issues = #report.dep_issues + #report.file_issues
+    if total_issues > 0 then
+        msg(('[watch] %d issue(s) detected'):format(total_issues))
+    end
+end
+
+windower.register_event('prerender', watch_tick)
+
+windower.register_event('addon command', function(...)
+    local args = {...}
+    local cmd = (args[1] or ''):lower():gsub('^%s+', ''):gsub('%s+$', '')
+
+    if cmd == '' or cmd == 'help' then
+        msg('Commands: check | watch on|off [interval] | export | status')
+        return
+    end
+
+    if cmd == 'check' or cmd == 'run' then
+        local report = run_diagnostics()
+        display_report(report)
+        return
+    end
+
+    if cmd == 'watch' then
+        local flag = (args[2] or ''):lower()
+        if flag == 'on' then
+            state.watchEnabled = true
+            local interval = tonumber(args[3])
+            if interval and interval >= 10 then state.watchInterval = interval end
+            msg(('Watch enabled (interval=%ds)'):format(state.watchInterval))
+        elseif flag == 'off' then
+            state.watchEnabled = false
+            msg('Watch disabled.')
+        else
+            msg(('Watch: %s (interval=%ds)'):format(state.watchEnabled and 'on' or 'off', state.watchInterval))
+        end
+        return
+    end
+
+    if cmd == 'export' then
+        local report = state.lastReport or run_diagnostics()
+        export_report(report)
+        return
+    end
+
+    if cmd == 'status' then
+        if state.lastReport then
+            display_report(state.lastReport)
+        else
+            msg('No report yet. Run //addonhealth check first.')
+        end
+        return
+    end
+
+    msg(('Unknown command "%s". Try //addonhealth help'):format(cmd))
+end)

--- a/libs/common.lua
+++ b/libs/common.lua
@@ -1,0 +1,210 @@
+local common = {}
+
+function common.normalize(s)
+    return (s or ''):lower():gsub('^%s+', ''):gsub('%s+$', '')
+end
+
+function common.normalize_command(raw)
+    return (raw or ''):gsub('^%s+', ''):gsub('%s+$', ''):gsub('^//', '')
+end
+
+function common.join(tbl, sep, start_idx)
+    local s = {}
+    for i = start_idx or 1, #tbl do s[#s+1] = tbl[i] end
+    return table.concat(s, sep or ' ')
+end
+
+function common.copy_table(t)
+    local out = {}
+    for k, v in pairs(t or {}) do
+        if type(v) == 'table' then out[k] = common.copy_table(v) else out[k] = v end
+    end
+    return out
+end
+
+function common.safe_load(path)
+    local ok, chunk = pcall(dofile, path)
+    if ok and type(chunk) == 'table' then return chunk end
+    return nil
+end
+
+function common.serialize_value(v, indent)
+    indent = indent or ''
+    if type(v) == 'string' then return string.format('%q', v) end
+    if type(v) == 'number' or type(v) == 'boolean' then return tostring(v) end
+    if type(v) == 'table' then
+        local next_indent = indent .. '  '
+        local lines = {'{'}
+        for k, vv in pairs(v) do
+            local key = (type(k) == 'string' and k:match('^[%a_][%w_]*$')) and k or ('[' .. common.serialize_value(k) .. ']')
+            lines[#lines+1] = next_indent .. key .. ' = ' .. common.serialize_value(vv, next_indent) .. ','
+        end
+        lines[#lines+1] = indent .. '}'
+        return table.concat(lines, '\n')
+    end
+    return 'nil'
+end
+
+function common.write_table_file(path, t)
+    local f = io.open(path, 'w')
+    if not f then return false end
+    f:write('return ', common.serialize_value(t), '\n')
+    f:close()
+    return true
+end
+
+function common.enc(s)
+    return tostring(s or ''):gsub('([^%w%-_%.~ ])', function(c) return string.format('%%%02X', string.byte(c)) end):gsub(' ', '+')
+end
+
+function common.dec(s)
+    s = (s or ''):gsub('+', ' ')
+    return s:gsub('%%(%x%x)', function(h) return string.char(tonumber(h, 16)) end)
+end
+
+function common.pack(prefix, t)
+    local parts = {}
+    for k, v in pairs(t or {}) do parts[#parts+1] = common.enc(k) .. '=' .. common.enc(v) end
+    return prefix .. '|' .. table.concat(parts, '&')
+end
+
+function common.unpack_payload(s)
+    local out = {}
+    for pair in (s or ''):gmatch('([^&]+)') do
+        local k, v = pair:match('([^=]+)=(.*)')
+        if k then out[common.dec(k)] = common.dec(v or '') end
+    end
+    return out
+end
+
+function common.valid_name(name)
+    return type(name) == 'string' and name:match('^[A-Za-z][A-Za-z0-9_%-]+$') ~= nil
+end
+
+function common.get_field(obj, path)
+    if not obj or not path then return nil end
+    local cur = obj
+    for part in tostring(path):gmatch('[^%.]+') do
+        if type(cur) ~= 'table' then return nil end
+        cur = cur[part]
+    end
+    return cur
+end
+
+function common.compare(op, left, right)
+    if op == '==' then return left == right end
+    if op == '!=' then return left ~= right end
+    if op == '>' then return tonumber(left) and tonumber(right) and tonumber(left) > tonumber(right) end
+    if op == '>=' then return tonumber(left) and tonumber(right) and tonumber(left) >= tonumber(right) end
+    if op == '<' then return tonumber(left) and tonumber(right) and tonumber(left) < tonumber(right) end
+    if op == '<=' then return tonumber(left) and tonumber(right) and tonumber(left) <= tonumber(right) end
+    if op == 'contains' then return tostring(left or ''):find(tostring(right or ''), 1, true) ~= nil end
+    if op == 'not_contains' then return tostring(left or ''):find(tostring(right or ''), 1, true) == nil end
+    if op == 'matches' then return tostring(left or ''):match(tostring(right or '')) ~= nil end
+    if op == 'in' and type(right) == 'table' then
+        for _, v in ipairs(right) do if left == v then return true end end
+        return false
+    end
+    if op == 'not_in' and type(right) == 'table' then
+        for _, v in ipairs(right) do if left == v then return false end end
+        return true
+    end
+    return false
+end
+
+local VALID_OPS = {
+    ['=='] = true, ['!='] = true, ['>'] = true, ['>='] = true,
+    ['<'] = true, ['<='] = true, ['contains'] = true, ['not_contains'] = true,
+    ['matches'] = true, ['in'] = true, ['not_in'] = true,
+}
+
+local VALID_ACTION_KINDS = {
+    ['mode.set'] = true, ['broadcast.travel'] = true, ['broadcast.command'] = true,
+    ['roster.target_set'] = true, ['notify'] = true, ['rule.disable'] = true,
+}
+
+function common.validate_rule(rule)
+    local errors = {}
+    if type(rule) ~= 'table' then return {'rule is not a table'} end
+    if type(rule.id) ~= 'string' or rule.id == '' then
+        errors[#errors+1] = 'rule missing id'
+    end
+    if rule.priority ~= nil and type(rule.priority) ~= 'number' then
+        errors[#errors+1] = ('rule %s: priority must be a number'):format(rule.id or '?')
+    end
+    if rule.cooldown_sec ~= nil and (type(rule.cooldown_sec) ~= 'number' or rule.cooldown_sec < 0) then
+        errors[#errors+1] = ('rule %s: cooldown_sec must be a non-negative number'):format(rule.id or '?')
+    end
+    if rule.when then
+        if type(rule.when) ~= 'table' then
+            errors[#errors+1] = ('rule %s: when must be a table'):format(rule.id or '?')
+        else
+            if rule.when.where then
+                if type(rule.when.where) ~= 'table' then
+                    errors[#errors+1] = ('rule %s: when.where must be a table'):format(rule.id or '?')
+                else
+                    for j, cond in ipairs(rule.when.where) do
+                        if type(cond) ~= 'table' then
+                            errors[#errors+1] = ('rule %s: where[%d] not a table'):format(rule.id or '?', j)
+                        elseif not cond.field then
+                            errors[#errors+1] = ('rule %s: where[%d] missing field'):format(rule.id or '?', j)
+                        elseif not cond.op or not VALID_OPS[cond.op] then
+                            errors[#errors+1] = ('rule %s: where[%d] invalid op "%s"'):format(rule.id or '?', j, tostring(cond.op))
+                        end
+                    end
+                end
+            end
+        end
+    end
+    if rule.then_actions then
+        if type(rule.then_actions) ~= 'table' then
+            errors[#errors+1] = ('rule %s: then_actions must be a table'):format(rule.id or '?')
+        else
+            for j, action in ipairs(rule.then_actions) do
+                if type(action) ~= 'table' then
+                    errors[#errors+1] = ('rule %s: action[%d] not a table'):format(rule.id or '?', j)
+                elseif not action.kind or not VALID_ACTION_KINDS[action.kind] then
+                    errors[#errors+1] = ('rule %s: action[%d] invalid kind "%s"'):format(rule.id or '?', j, tostring(action.kind))
+                end
+            end
+        end
+    end
+    return errors
+end
+
+function common.validate_route(dest, route)
+    local errors = {}
+    if type(route) ~= 'table' then
+        return {('route "%s" is not a table'):format(dest)}
+    end
+    local candidates = route.candidates
+    if not candidates then
+        if route[1] and type(route[1]) == 'string' then
+            return errors
+        end
+        if route.steps then
+            candidates = { route }
+        else
+            errors[#errors+1] = ('route "%s": no candidates or steps found'):format(dest)
+            return errors
+        end
+    end
+    for i, c in ipairs(candidates) do
+        if type(c) ~= 'table' then
+            errors[#errors+1] = ('route "%s" candidate[%d]: not a table'):format(dest, i)
+        else
+            if not c.steps or type(c.steps) ~= 'table' or #c.steps == 0 then
+                errors[#errors+1] = ('route "%s" candidate "%s": empty or missing steps'):format(dest, c.name or i)
+            else
+                for j, step in ipairs(c.steps) do
+                    if type(step) ~= 'string' or step == '' then
+                        errors[#errors+1] = ('route "%s" candidate "%s" step[%d]: invalid'):format(dest, c.name or i, j)
+                    end
+                end
+            end
+        end
+    end
+    return errors
+end
+
+return common

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+EXIT_CODE=0
+PASS=0
+FAIL=0
+WARN=0
+
+pass() { PASS=$((PASS+1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL+1)); EXIT_CODE=1; echo "  FAIL: $1"; }
+warn() { WARN=$((WARN+1)); echo "  WARN: $1"; }
+
+echo "=== FFXI Addon Landscape Validation ==="
+echo ""
+
+# 1. Lua syntax check
+echo "[1/5] Lua syntax check"
+LUA_CMD=""
+if command -v luac >/dev/null 2>&1; then
+    LUA_CMD="luac"
+elif command -v luac5.1 >/dev/null 2>&1; then
+    LUA_CMD="luac5.1"
+fi
+
+if [ -n "$LUA_CMD" ]; then
+    while IFS= read -r -d '' f; do
+        if $LUA_CMD -p "$f" 2>/dev/null; then
+            pass "$(basename "$f") syntax OK"
+        else
+            fail "$(basename "$f") syntax error"
+        fi
+    done < <(find "$REPO_ROOT/addons" "$REPO_ROOT/libs" -name '*.lua' -print0 2>/dev/null)
+else
+    warn "luac not found, skipping Lua syntax checks"
+fi
+
+# 2. JSON catalog validation
+echo ""
+echo "[2/5] JSON catalog validation"
+CATALOG="$REPO_ROOT/ffxi-addon-catalog-normalized.json"
+if [ -f "$CATALOG" ]; then
+    if python3 -c "
+import json, sys
+with open('$CATALOG') as f:
+    data = json.load(f)
+if not isinstance(data, list):
+    print('catalog is not a list', file=sys.stderr); sys.exit(1)
+missing = []
+for i, entry in enumerate(data):
+    for field in ['addon_name', 'addon_key', 'category']:
+        if field not in entry:
+            missing.append(f'entry {i} missing {field}')
+if missing:
+    for m in missing[:10]:
+        print(m, file=sys.stderr)
+    sys.exit(1)
+print(f'{len(data)} entries validated')
+" 2>&1; then
+        pass "catalog JSON valid"
+    else
+        fail "catalog JSON validation failed"
+    fi
+else
+    warn "catalog file not found"
+fi
+
+# 3. Rule validation
+echo ""
+echo "[3/5] Rule file validation"
+RULES_FILE="$REPO_ROOT/addons/SessionConductor/data/rules.default.lua"
+if [ -f "$RULES_FILE" ]; then
+    if python3 -c "
+import re, sys
+
+with open('$RULES_FILE') as f:
+    content = f.read()
+
+ids = re.findall(r\"id\s*=\s*['\\\"]([^'\\\"]+)\", content)
+if not ids:
+    print('no rule IDs found', file=sys.stderr); sys.exit(1)
+seen = set()
+for rid in ids:
+    if rid in seen:
+        print(f'duplicate rule id: {rid}', file=sys.stderr); sys.exit(1)
+    seen.add(rid)
+
+required_fields = ['enabled', 'priority', 'when', 'then_actions']
+for field in required_fields:
+    if field not in content:
+        print(f'missing field pattern: {field}', file=sys.stderr); sys.exit(1)
+
+print(f'{len(ids)} rules with unique IDs')
+" 2>&1; then
+        pass "rules.default.lua valid"
+    else
+        fail "rules.default.lua validation failed"
+    fi
+else
+    fail "rules.default.lua not found"
+fi
+
+# 4. Route validation
+echo ""
+echo "[4/5] Route file validation"
+ROUTES_FILE="$REPO_ROOT/addons/TravelRouter/data/routes.lua"
+if [ -f "$ROUTES_FILE" ]; then
+    if python3 -c "
+import re, sys
+
+with open('$ROUTES_FILE') as f:
+    content = f.read()
+
+dests = re.findall(r'^\s*(\w+)\s*=\s*\{', content, re.MULTILINE)
+if not dests:
+    print('no destinations found', file=sys.stderr); sys.exit(1)
+
+steps_count = len(re.findall(r\"(say|cmd|wait):\", content))
+if steps_count == 0:
+    print('no step patterns found', file=sys.stderr); sys.exit(1)
+
+print(f'{len(dests)} destinations, {steps_count} steps')
+" 2>&1; then
+        pass "routes.lua valid"
+    else
+        fail "routes.lua validation failed"
+    fi
+else
+    fail "routes.lua not found"
+fi
+
+# 5. Unit tests
+echo ""
+echo "[5/5] Unit tests"
+if command -v lua >/dev/null 2>&1 || command -v lua5.1 >/dev/null 2>&1; then
+    LUA_RUN=""
+    if command -v lua5.1 >/dev/null 2>&1; then
+        LUA_RUN="lua5.1"
+    elif command -v lua >/dev/null 2>&1; then
+        LUA_RUN="lua"
+    fi
+
+    if [ -n "$LUA_RUN" ]; then
+        cd "$REPO_ROOT/tests"
+        if $LUA_RUN test_common.lua 2>&1; then
+            pass "test_common.lua"
+        else
+            fail "test_common.lua"
+        fi
+        cd "$REPO_ROOT"
+    fi
+else
+    warn "lua not found, skipping unit tests"
+fi
+
+# Summary
+echo ""
+echo "=== Summary ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+echo "  Warnings: $WARN"
+echo ""
+
+exit $EXIT_CODE

--- a/tests/mock_windower.lua
+++ b/tests/mock_windower.lua
@@ -1,0 +1,68 @@
+local mock = {}
+
+local chat_log = {}
+local ipc_messages = {}
+local sent_commands = {}
+local registered_events = {}
+local event_counter = 0
+
+local player = { name = 'TestPlayer', target_index = nil, buffs = {} }
+local info = { zone = 100, status = 0 }
+local party_data = {}
+
+function mock.reset()
+    chat_log = {}
+    ipc_messages = {}
+    sent_commands = {}
+    registered_events = {}
+    event_counter = 0
+    player = { name = 'TestPlayer', target_index = nil, buffs = {} }
+    info = { zone = 100, status = 0 }
+    party_data = {}
+end
+
+function mock.set_player(p) player = p end
+function mock.set_info(i) info = i end
+function mock.set_party(p) party_data = p end
+function mock.get_chat_log() return chat_log end
+function mock.get_ipc_messages() return ipc_messages end
+function mock.get_sent_commands() return sent_commands end
+
+function mock.install()
+    _G.windower = {
+        addon_path = '/tmp/ffxi-addon-landscape-1776909766/tests/fixtures/',
+        add_to_chat = function(color, text)
+            chat_log[#chat_log+1] = { color = color, text = text }
+        end,
+        send_command = function(cmd)
+            sent_commands[#sent_commands+1] = cmd
+        end,
+        send_ipc_message = function(data)
+            ipc_messages[#ipc_messages+1] = data
+        end,
+        register_event = function(name, fn)
+            event_counter = event_counter + 1
+            registered_events[event_counter] = { name = name, fn = fn }
+            return event_counter
+        end,
+        unregister_event = function(id)
+            registered_events[id] = nil
+        end,
+        ffxi = {
+            get_player = function() return player end,
+            get_info = function() return info end,
+            get_party = function() return party_data end,
+        },
+    }
+    _G._addon = {}
+end
+
+function mock.fire_event(name, ...)
+    for _, entry in pairs(registered_events) do
+        if entry.name == name then
+            entry.fn(...)
+        end
+    end
+end
+
+return mock

--- a/tests/test_common.lua
+++ b/tests/test_common.lua
@@ -1,0 +1,116 @@
+package.path = '../libs/?.lua;' .. package.path
+
+local common = require('common')
+
+local pass, fail, total = 0, 0, 0
+
+local function check(label, cond)
+    total = total + 1
+    if cond then
+        pass = pass + 1
+    else
+        fail = fail + 1
+        io.stderr:write(('FAIL: %s\n'):format(label))
+    end
+end
+
+-- normalize
+check('normalize lowercases', common.normalize('HELLO') == 'hello')
+check('normalize trims', common.normalize('  foo  ') == 'foo')
+check('normalize nil safe', common.normalize(nil) == '')
+
+-- normalize_command
+check('normalize_command strips //', common.normalize_command('//send') == 'send')
+check('normalize_command trims', common.normalize_command('  input /ma  ') == 'input /ma')
+
+-- join
+check('join default', common.join({'a','b','c'}) == 'a b c')
+check('join from 2', common.join({'a','b','c'}, ' ', 2) == 'b c')
+check('join custom sep', common.join({'a','b'}, ',') == 'a,b')
+
+-- copy_table
+local orig = {x = 1, sub = {y = 2}}
+local c = common.copy_table(orig)
+check('copy_table deep', c.sub.y == 2)
+c.sub.y = 99
+check('copy_table independent', orig.sub.y == 2)
+
+-- serialize_value
+check('serialize string', common.serialize_value('hi') == '"hi"')
+check('serialize number', common.serialize_value(42) == '42')
+check('serialize bool', common.serialize_value(true) == 'true')
+check('serialize nil', common.serialize_value(nil) == 'nil')
+
+-- enc/dec roundtrip
+local encoded = common.enc('hello world!')
+local decoded = common.dec(encoded)
+check('enc/dec roundtrip', decoded == 'hello world!')
+
+-- pack/unpack roundtrip
+local packed = common.pack('TEST', {op = 'run', dest = 'jeuno'})
+check('pack has prefix', packed:sub(1,5) == 'TEST|')
+local _, payload = packed:match('^(TEST)|(.*)')
+local unpacked = common.unpack_payload(payload)
+check('unpack op', unpacked.op == 'run')
+check('unpack dest', unpacked.dest == 'jeuno')
+
+-- valid_name
+check('valid_name ok', common.valid_name('Alice') == true)
+check('valid_name with dash', common.valid_name('Alt-Char') == true)
+check('valid_name numeric start', common.valid_name('1abc') == false)
+check('valid_name nil', common.valid_name(nil) == false)
+check('valid_name empty', common.valid_name('') == false)
+
+-- get_field
+local obj = {payload = {hp_pct = 25}, party = {size = 3}}
+check('get_field simple', common.get_field(obj, 'payload.hp_pct') == 25)
+check('get_field nested', common.get_field(obj, 'party.size') == 3)
+check('get_field missing', common.get_field(obj, 'payload.missing') == nil)
+check('get_field nil obj', common.get_field(nil, 'x') == nil)
+
+-- compare
+check('compare ==', common.compare('==', 'a', 'a') == true)
+check('compare !=', common.compare('!=', 'a', 'b') == true)
+check('compare >', common.compare('>', 10, 5) == true)
+check('compare <=', common.compare('<=', 5, 5) == true)
+check('compare contains', common.compare('contains', 'hello world', 'world') == true)
+check('compare not_contains', common.compare('not_contains', 'hello', 'xyz') == true)
+check('compare matches', common.compare('matches', 'abc123', '%d+') == true)
+check('compare in', common.compare('in', 'b', {'a','b','c'}) == true)
+check('compare not_in', common.compare('not_in', 'z', {'a','b'}) == true)
+
+-- validate_rule
+local good_rule = {
+    id = 'test.rule', enabled = true, priority = 50, cooldown_sec = 5,
+    when = { event = 'party.member.hp_low', where = {{ field = 'payload.hp_pct', op = '<=', value = 40 }} },
+    then_actions = {{ kind = 'notify', text = 'Low HP' }},
+}
+check('validate_rule good', #common.validate_rule(good_rule) == 0)
+
+local bad_rule = {
+    id = 'bad.rule', priority = 'high',
+    when = { where = {{ field = 'x', op = 'BOGUS' }} },
+    then_actions = {{ kind = 'explode' }},
+}
+local errs = common.validate_rule(bad_rule)
+check('validate_rule catches errors', #errs >= 2)
+
+check('validate_rule no id', #common.validate_rule({}) > 0)
+
+-- validate_route
+local good_route = {
+    candidates = {{ name = 'direct', score = 10, steps = {'say:go', 'cmd:warp'} }}
+}
+check('validate_route good', #common.validate_route('jeuno', good_route) == 0)
+
+local bad_route = {
+    candidates = {{ name = 'broken', steps = {} }}
+}
+check('validate_route empty steps', #common.validate_route('bad', bad_route) > 0)
+check('validate_route not table', #common.validate_route('x', 'string') > 0)
+
+-- simple list route
+check('validate_route simple list', #common.validate_route('x', {'say:go', 'cmd:warp'}) == 0)
+
+print(('\n%d/%d tests passed, %d failed'):format(pass, total, fail))
+os.exit(fail > 0 and 1 or 0)

--- a/tests/test_sessionconductor.lua
+++ b/tests/test_sessionconductor.lua
@@ -1,0 +1,137 @@
+package.path = '../tests/?.lua;../libs/?.lua;../addons/SessionConductor/?.lua;' .. package.path
+
+local mock = require('mock_windower')
+mock.reset()
+mock.install()
+
+local pass, fail, total = 0, 0, 0
+local function check(label, cond)
+    total = total + 1
+    if cond then
+        pass = pass + 1
+    else
+        fail = fail + 1
+        io.stderr:write(('FAIL: %s\n'):format(label))
+    end
+end
+
+dofile('../addons/SessionConductor/sessionconductor.lua')
+
+-- test help
+mock.fire_event('addon command', 'help')
+local log = mock.get_chat_log()
+check('help produces output', #log > 0)
+
+-- test status
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'status')
+log = mock.get_chat_log()
+check('status produces output', #log > 0)
+
+-- test ping
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'ping')
+local ipc = mock.get_ipc_messages()
+check('ping sends ipc', #ipc > 0)
+check('ping ipc has SC2', ipc[1] and ipc[1]:find('SC2') ~= nil)
+
+-- test auto toggle
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'auto', 'off')
+log = mock.get_chat_log()
+check('auto off acknowledged', #log > 0)
+
+mock.fire_event('addon command', 'auto', 'on')
+log = mock.get_chat_log()
+check('auto on acknowledged', #log > 1)
+
+-- test mode
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'mode', 'emergency')
+log = mock.get_chat_log()
+check('mode set acknowledged', #log > 0)
+check('mode mentions emergency', log[#log] and log[#log].text:find('emergency') ~= nil)
+
+-- test trace
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'trace', 'on')
+log = mock.get_chat_log()
+check('trace on acknowledged', #log > 0)
+
+-- test emit
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'emit', 'test.event')
+log = mock.get_chat_log()
+check('emit acknowledged', #log > 0)
+
+-- test rules list
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'rules', 'list')
+log = mock.get_chat_log()
+check('rules list produces output', #log > 0)
+
+-- test events tail
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'emit', 'foo.bar')
+mock.fire_event('addon command', 'events', 'tail', '5')
+log = mock.get_chat_log()
+check('events tail produces output', #log > 0)
+
+-- test sensor display
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'sensor')
+log = mock.get_chat_log()
+check('sensor shows distance', #log > 0)
+
+-- test roster list
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'roster', 'list')
+log = mock.get_chat_log()
+check('roster list produces output', #log > 0)
+
+-- test remotecmd toggle
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'remotecmd', 'on')
+log = mock.get_chat_log()
+check('remotecmd on acknowledged', #log > 0)
+
+-- test unknown command
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('addon command', 'zzz_unknown')
+log = mock.get_chat_log()
+check('unknown cmd gives message', #log > 0)
+
+-- test IPC pong response
+mock.reset()
+mock.install()
+dofile('../addons/SessionConductor/sessionconductor.lua')
+mock.fire_event('ipc message', 'SC2R|op=pong&from=OtherPlayer')
+log = mock.get_chat_log()
+check('pong shows source', #log > 0)
+
+print(('\n%d/%d tests passed, %d failed'):format(pass, total, fail))
+os.exit(fail > 0 and 1 or 0)

--- a/tests/test_travelrouter.lua
+++ b/tests/test_travelrouter.lua
@@ -1,0 +1,89 @@
+package.path = '../tests/?.lua;../libs/?.lua;../addons/TravelRouter/?.lua;' .. package.path
+
+local mock = require('mock_windower')
+mock.reset()
+mock.install()
+
+local pass, fail, total = 0, 0, 0
+local function check(label, cond)
+    total = total + 1
+    if cond then
+        pass = pass + 1
+    else
+        fail = fail + 1
+        io.stderr:write(('FAIL: %s\n'):format(label))
+    end
+end
+
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+-- test list command
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'list')
+local log = mock.get_chat_log()
+check('list produces output', #log > 0)
+check('list mentions destinations', log[1] and log[1].text:find('destinations') ~= nil)
+
+-- test plan with known destination
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'plan', 'jeuno')
+log = mock.get_chat_log()
+check('plan produces output', #log > 0)
+check('plan mentions jeuno', log[1] and log[1].text:find('jeuno') ~= nil)
+
+-- test plan with unknown destination
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'plan', 'nonexistent')
+log = mock.get_chat_log()
+check('unknown plan gives message', #log > 0)
+check('unknown plan mentions no route', log[1] and log[1].text:find('No route') ~= nil)
+
+-- test help command
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'help')
+log = mock.get_chat_log()
+check('help produces output', #log > 0)
+
+-- test unlock list
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'unlock', 'list')
+log = mock.get_chat_log()
+check('unlock list produces output', #log > 0)
+
+-- test IPC v2
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('ipc message', 'TR2|op=plan&dest=jeuno')
+local ipc = mock.get_ipc_messages()
+check('ipc plan sends reply', #ipc > 0)
+check('ipc reply has TR2R prefix', ipc[1] and ipc[1]:sub(1,4) == 'TR2R')
+
+-- test unknown command
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'bogus')
+log = mock.get_chat_log()
+check('unknown cmd gives message', #log > 0)
+check('unknown cmd mentions unknown', log[1] and log[1].text:find('Unknown') ~= nil)
+
+print(('\n%d/%d tests passed, %d failed'):format(pass, total, fail))
+os.exit(fail > 0 and 1 or 0)


### PR DESCRIPTION
## Summary
- add a new `AddonHealth` addon for cross-addon diagnostics, dependency checks, file checks, watch mode, and exportable health reports
- add shared `libs/common.lua` helpers for normalization, serialization, payload parsing, and route/rule validation
- add repo validation tooling via `scripts/validate.sh`
- add Lua test scaffolding and unit tests for common helpers, SessionConductor command behavior, and TravelRouter behavior

## Why
This pushes the project toward a more production-ready addon ecosystem with better observability, safer data validation, and a foundation for repeatable testing.

## Validation
Ran:
- `./scripts/validate.sh`

Result:
- catalog JSON validated
- rules file validated
- routes file validated
- warnings only for missing local `luac` and `lua` binaries in this environment

## Notes
- AddonHealth loaded-addon detection was adjusted to tolerate multiple Windower addon table shapes to avoid the earlier false-negative pattern.
