### PR TITLE
4h sync: refresh FFXI addon catalog/index (2026-04-23 12:00 UTC)

### DIFF
--- a/docs/sync-2026-04-23-1200.md
+++ b/docs/sync-2026-04-23-1200.md
@@ -1,0 +1,77 @@
+# 4h Sync Report — 2026-04-23 12:00 UTC
+
+## Scope
+Catalog/index/docs maintenance only:
+- `ffxi_addons_index_raw.json`
+- `ffxi-addon-catalog-normalized.json`
+- `ffxi-addon-catalog-normalized.csv`
+- `docs/sync-2026-04-23-1200.md`
+
+## Repository deltas
+### Added repos
+- `iLVL-Key/FFXI`
+- `mousseng/xitools`
+- `Tylas11/XivParty`
+- `onimitch/ffxi-zonename`
+- `SQLCommit/LootScope`
+- `SQLCommit/ZoneLines`
+- `SQLCommit/MemScope`
+- `SQLCommit/GMTools`
+
+### Updated repo metadata
+Refreshed stars / pushed_at / descriptions for indexed repos from GitHub API.
+
+### Removed repos
+- None in this sync.
+
+## Addon deltas (normalized catalog)
+### Newly added addon entries
+- `attend`
+- `bars`
+- `battleplan`
+- `bluspells`
+- `callouts`
+- `chatty`
+- `colure`
+- `dxui`
+- `emotes`
+- `exorcist`
+- `ffxi-zonename`
+- `gaolplan`
+- `gmtools`
+- `helper`
+- `imrecast`
+- `informer`
+- `jingle`
+- `leaderboard`
+- `llmchat`
+- `loggers`
+- `memscope`
+- `minimap-helper`
+- `rcheck`
+- `readycheck`
+- `relicge`
+- `repl`
+- `strats`
+- `sweeper`
+- `taskbar`
+- `trials`
+- `vanafacts`
+- `vanapad`
+- `vanity`
+- `wheel`
+- `xitools`
+- `znmtracker`
+- `zonelines`
+
+### Removed/stale addon entries
+- None removed in this pass.
+
+## Confidence notes
+- **High confidence** for repo existence, stars, and push timestamps (GitHub API source).
+- **Medium confidence** for single-purpose repo addon mapping (repo/addon folder naming aligns with addon identity).
+- **Lower confidence** for some multi-addon repos where folder names may include support modules or shared libraries.
+
+## Validation
+- JSON artifacts parsed successfully (`python3 -m json.tool`).
+- CSV regenerated from normalized JSON and row count verified.

--- a/ffxi-addon-catalog-normalized.csv
+++ b/ffxi-addon-catalog-normalized.csv
@@ -1,250 +1,296 @@
 addon_key,addon_name,category,repos,repo_count,best_repo_stars,freshness_max,opportunity_score,description,description_source,description_confidence
-xipivot,XIPivot,general_qol,HealsCodes/XIPivot,1,61,5,4.3,FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs,https://github.com/HealsCodes/XIPivot,medium
-trust,trust,automation,cyritegamestudios/trust,1,49,5,4.26,Windower 4 addon for FFXI to automate your character in battle.,https://github.com/cyritegamestudios/trust,medium
-xichecklist,XIchecklist,travel_navigation,HiPotionQ8/XIchecklist,1,4,5,3.89,"windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",https://github.com/HiPotionQ8/XIchecklist,medium
-tourist,tourist,travel_navigation,Bryenne-Sylph/tourist,1,3,5,3.85,An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ,https://github.com/Bryenne-Sylph/tourist,medium
-atreplace,atreplace,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"For more details: https://www.ffxiah.com/forum/topic/58154/atreplace-autotranslate-in-scripts-and-aliases/ _**USE THIS AT YOUR OWN RISK**_, I did my best to make sure it copied client behavior 100% but it's entirely poss",https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/atreplace/README.md,high
-augments,augments,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"augments: search items by name and print their augments to chatlog. If you need to know how many Chironic Hoses you own, and what their augments are.",https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-chatfix,chatfix,chat_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"create a windowerfolder\addons\chatfix folder, and put chatfix.lua there",https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/chatfix/README.md,high
-clevel,clevel,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,clevel: prints your current true master level to chatlog while under level sync.,https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-collector,collector,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,# Collector Finds owned and missing items from a collection of items.,https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/collector/README.md,high
-dramagen,dramagen,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,Dramagen: the only and last parser you will ever need.,https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-gilbox,gilbox,economy_inventory,lili-ffxi/FFXI-Addons,1,35,5,3.84,"Inventory/economy helper for storage, movement, and selling tasks.",heuristic,low
-indinope,indinope,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,# IndiNope 1.0.4 Hides visual effects from geomancy on players.,https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/indinope/README.md,high
-jobinit,jobinit,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"JobInit: like init.txt, but specific per character per job.",https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-kaomoji,kaomoji,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,kaomoji: minimal kaomoji support for ffxi (behaves like /shrug /tableflip and /unflip do on discord),https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-menufix,menufix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"create a windowerfolder\addons\menufix folder, and put menufix.lua there",https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/menufix/README.md,high
-mousehalo,mousehalo,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"mousehalo (makes your mouse cursor MUCH more visible. A bit facetious, but working.)",https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-ondemand,ondemand,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,General FFXI quality-of-life utility addon.,heuristic,low
-positionmanager,position_manager,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"**Note**: On some systems with very fast or very slow disks, it can happen that the WinControl addon does not get loaded in time for position_manager to send the proper command.",https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/position_manager/readme.md,high
-readable,readable,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,General FFXI quality-of-life utility addon.,heuristic,low
-safeoboro,safeoboro,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,This addon creates a zone of 10' around Oboro where every player that is not you cannot appear. Load it and it's on. Load it before zoning into Port Jeuno for maximum effectiveness. Enjoy some privacy with Oboro! Say goo,https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/safeoboro/README.md,high
-silttracker,silttracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,# silttracker This is a very simple tool I wrote for myself to easily track the earning of beads during intense farming sessions.,https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/silttracker/README.md,high
-smeagol,smeagol,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,Does not use rings inside town. Can toggle with //smeagol town command.,https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/smeagol/README.md,high
-special,special,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,special: makes you feel special.,https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-tellapart,tellapart,chat_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"Get support for the addon on FFXIAH: https://www.ffxiah.com/forum/topic/57093/tellapart-add-progressive-letters-to-mob-names/ Names are changed in a way that they are identical across different clients, even if those cli",https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/tellapart/README.md,high
-tellfix,tellfix,chat_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"create a windowerfolder\addons\tellfix folder, and put tellfix.lua there",https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/tellfix/README.md,high
-tiptoes,tiptoes,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"tiptoes: applies Sneak and Invisible with a single command according to job: supports spells, Spectral Jig, Ninjutsu, and items (Silent Oils and Prism Powders).",https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-tpsreport,tpsreport,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,TPSReport: exports an XML list of current alliance members.,https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-trialtracker,trialtracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,General FFXI quality-of-life utility addon.,heuristic,low
-useall,useall,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,General FFXI quality-of-life utility addon.,heuristic,low
-waveback,waveback,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,//waveback delay &lt;number&gt; - waits <number> between activations.,https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/waveback/README.md,high
-weathermon,weathermon,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,General FFXI quality-of-life utility addon.,heuristic,low
-witnessprotection,witnessprotection,general_qol,lili-ffxi/FFXI-Addons,1,35,5,3.84,"# Witness Protection ver. 0.2.0 This addon takes care of renaming all the characters you encounter to random names. The goal is to make it impossible, or at least very difficult, to recognize who you are or what server y",https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/witnessprotection/README.md,high
-clickfind,clickfind,general_qol,Icydeath/ffxi-addons; lili-ffxi/FFXI-Addons,2,69,5,3.12,clickfind (click to print mouse cursor position on screen),https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-dupefind,Dupefind,general_qol,Icydeath/ffxi-addons; lili-ffxi/FFXI-Addons,2,69,5,3.12,"Dupefind (by Lili, modded by me) : Find and lists duplicate items.",https://github.com/Icydeath/ffxi-addons#readme,medium
-friendzone,friendzone,general_qol,Icydeath/ffxi-addons; lili-ffxi/FFXI-Addons,2,69,5,3.12,Friendzone: automatically calls trusts over and over. A bit bugged but workable.,https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-posfind,posfind,general_qol,Icydeath/ffxi-addons; lili-ffxi/FFXI-Addons,2,69,5,3.12,posfind (click to print character position on world map),https://github.com/lili-ffxi/FFXI-Addons#readme,medium
-statsearch,StatSearch,general_qol,Icydeath/ffxi-addons; lili-ffxi/FFXI-Addons,2,69,5,3.12,"# statsearch **NOTE:** due to limitations of the extdata library of windower, statsearch is currently unable to read text from some items, mainly divergence weapons/necks and odyssey gear.",https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/statsearch/README.md,high
-debufftracker,debuff-tracker,general_qol,ProjectTako/ffxi-addons,1,99,2,2.95,General FFXI quality-of-life utility addon.,heuristic,low
-menus,menus,general_qol,ProjectTako/ffxi-addons,1,99,2,2.95,# ffxi-addons/menus Menus: Menus is an addon for Ashita that allows you to open your delivery box and the auction house anywhere in a zone that normally has those accessible.,https://github.com/ProjectTako/ffxi-addons/blob/HEAD/menus/README.md,high
-scanzone,scanzone,general_qol,ProjectTako/ffxi-addons,1,99,2,2.95,"# ffxi-addons/scanzone ScanZone: Scan Zone is an addon that will let you scan your current zone for any NPC, including mobs.",https://github.com/ProjectTako/ffxi-addons/blob/HEAD/scanzone/README.md,high
-turnaround,turnaround,general_qol,ProjectTako/ffxi-addons,1,99,2,2.95,# ffxi-addons/turnaround TurnAround: Simple addon used for turning yourself around.,https://github.com/ProjectTako/ffxi-addons/blob/HEAD/turnaround/README.md,high
-autodnc,AutoDNC,combat_automation,Ivaar/Windower-addons,1,79,2,2.9,Automates repeated job or combat actions with rule-based logic.,heuristic,low
-chococard,chococard,general_qol,Ivaar/Windower-addons,1,79,2,2.9,Chococard === Displays decoded extra data for chocobo items and packets while viewing the padocks inside race track menus.,https://github.com/Ivaar/Windower-addons/blob/HEAD/chococard/README.md,high
-questlog,QuestLog,diagnostics,Ivaar/Windower-addons,1,79,2,2.9,# QuestLog used to track progress for adoulin/abyssea quest completion shows abyssea and adoulin quests you have not completed or undertaken ### Commands: ### Color code:,https://github.com/Ivaar/Windower-addons/blob/HEAD/QuestLog/README.md,high
-bursting,Bursting,general_qol,ValokAsura/WindowerAddons,1,14,2,2.74,General FFXI quality-of-life utility addon.,heuristic,low
-crystaltrader,CrystalTrader,economy_inventory,ValokAsura/WindowerAddons,1,14,2,2.74,Crystal Trader has been replaced with QuickTrade and will no longer be updated.,https://github.com/ValokAsura/WindowerAddons/blob/HEAD/CrystalTrader/readme.md,high
-quicktrade2,QuickTrade 2,economy_inventory,ValokAsura/WindowerAddons,1,14,2,2.74,"Inventory/economy helper for storage, movement, and selling tasks.",heuristic,low
-assist,assist,combat_automation,DiscipleOfEris/Windower4Addons,1,12,2,2.73,Keeps your target synced by assisting a chosen party member.,heuristic,low
-eradebuffed,EraDebuffed,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,2.73,General FFXI quality-of-life utility addon.,heuristic,low
-eradistanceplus,EraDistancePlus,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,2.73,General FFXI quality-of-life utility addon.,heuristic,low
-erainfobar,EraInfoBar,ui_gear,DiscipleOfEris/Windower4Addons,1,12,2,2.73,"UI enhancement for combat, targeting, or gear visibility.",heuristic,low
-erajobchange,EraJobChange,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,2.73,General FFXI quality-of-life utility addon.,heuristic,low
-eramobdrops,EraMobDrops,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,2.73,General FFXI quality-of-life utility addon.,heuristic,low
-eramoblevel,EraMobLevel,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,2.73,General FFXI quality-of-life utility addon.,heuristic,low
-erapointwatch,EraPointWatch,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,2.73,General FFXI quality-of-life utility addon.,heuristic,low
-erascoreboard,EraScoreboard,ui_gear,DiscipleOfEris/Windower4Addons,1,12,2,2.73,"UI enhancement for combat, targeting, or gear visibility.",heuristic,low
-fastfollow,FastFollow,combat_automation,DiscipleOfEris/Windower4Addons,1,12,2,2.73,"Combat helper automating timing, actions, or role behavior.",heuristic,low
-ambuloot,ambuloot,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-attackid,attackid,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,# attackid idを指定して/attack(戦闘開始)をするアドオン - 使い方 //atkid 123456 sendから使用する //send @others atkid <tid>,https://github.com/Icydeath/ffxi-addons/blob/HEAD/attackid/README.md,high
-attackwithme,attackwithme,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,# attackwithme - by yyoshisaur ### :tada: v0.0.7 - modded by icy #### New Settings {...} are optional //awm set master {name} ~ sets current player or name to auto load as master //awm set slave {name} ~ sets current pla,https://github.com/Icydeath/ffxi-addons/blob/HEAD/attackwithme/README.md,high
-autochain,AutoChain,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,Automates repeated job or combat actions with rule-based logic.,heuristic,low
-autopup,AutoPUP,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,Automates repeated job or combat actions with rule-based logic.,heuristic,low
-autoraise,AutoRaise,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,Automates repeated job or combat actions with rule-based logic.,heuristic,low
-autoskillchain,AutoSkillchain,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,"Some have been modified by me to suit my own needs, full credit goes to the original creators._ **allseeingeye** by Project Tako **AllWarps** by Ivaar - Gives access to the menu options for the following warps: Homepoint",https://github.com/Icydeath/ffxi-addons#readme,medium
-autounm,AutoUNM,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,Automates repeated job or combat actions with rule-based logic.,heuristic,low
-autovw,AutoVW,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,Automates repeated job or combat actions with rule-based logic.,heuristic,low
-autowatch,autowatch,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,**update 1/17/2021** autowatch (by Langly) : I've had some success with this one.,https://github.com/Icydeath/ffxi-addons#readme,medium
-blist,blist,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-canteen,Canteen,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,# Canteen Load it up then //canteen get when in the #10 portal to get canteen.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/Canteen/README.md,high
-capetrader,capetrader,economy_inventory,Icydeath/ffxi-addons,1,69,1,2.52,___ ### Usage notes Load the addon by using the following command: //lua load capetrader There are some conditions that you need to meet in order to use the important go and prep commands: 1.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/capetrader/README.md,high
-charmed,charmed,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,"## charmed Created by wes, modified by icy v0.3 : Simple addon to show a pink <3 next to charmed alliance members.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/charmed/README.md,high
-checkparam,checkparam,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,//checkparam OR //cp (addon command),https://github.com/Icydeath/ffxi-addons/blob/HEAD/checkparam/README.md,high
-crbaddon,crb_addon,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-curepleaseaddon,CurePlease_addon,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-currencies,Currencies,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,Currencies (by Ivaar) : use commands to find the amount of something that is listed your currency/currency2 in-game menus.,https://github.com/Icydeath/ffxi-addons#readme,medium
-distanceplus,DistancePlus,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,Distance Plus adds the following features: * Distance measured to hundredth vs 10th.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/DistancePlus/readme.md,high
-drop,Drop,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,"register chamber, enter chamber, drop lamp ---- If you need further information be sure to check out the addons readme file, otherwise you can skim the addons .lua to get an idea of how it works.",https://github.com/Icydeath/ffxi-addons#readme,medium
-eschachest,EschaChest,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,EschaChest (by me) : a first attempt at automate opening of chests in escha zones.,https://github.com/Icydeath/ffxi-addons#readme,medium
-exportitems,export_items,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-ffxikeys,ffxikeys,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,Original creator: Tny5989 Modified by: Icy # FFXIKeys A small windower addon to automate trading keys for rewards Action | Addon Command --------------------- | ----------------------------- Use | //keys use \<key\> Togg,https://github.com/Icydeath/ffxi-addons/blob/HEAD/ffxikeys/README.md,high
-finalalert,finalAlert,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-followme,followme,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,# followme * フォロー開始 //followme(//fm) start * フォロー解除 //followme(//fm) stop * イオニス取得 //followme(//fm) ionis * 飯盒(オーメン)取得 //followme(//fm) canteen * 祈祷神符(ドメインベージョン)取得 -> 会場へワープ //followme(//fm) di * マウント(ラプトル)に乗る //followme,https://github.com/Icydeath/ffxi-addons/blob/HEAD/followme/README.md,high
-giltracker,giltracker,economy_inventory,Icydeath/ffxi-addons,1,69,1,2.52,"# giltracker This addon displays the current gil, similar to the FFXIV Gil HUD widget.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/giltracker/README.md,high
-jobchange,JobChange,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,Allows command line job change as long as you're within 6 yalms of a Job Change NPC.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/JobChange/README.md,high
-locke,Locke,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,"followme (by yyoshisaur, modded by me) : alt following, get omen canteen, get SR KI, get DI KI Locke (by me) : experimental thf TH Gear swapper.",https://github.com/Icydeath/ffxi-addons#readme,medium
-lockpick,lockpick,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-maga,maga,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,Edit the buy_list in file **InvSpace** by Kenshi - Shows each inventory containers free space in a moveable box **Juggler** by psykad - Juggler is to simplify the use of Ready commands for jug pets **lazyMB** by kotodama,https://github.com/Icydeath/ffxi-addons#readme,medium
-masstrade,MassTrade,economy_inventory,Icydeath/ffxi-addons,1,69,1,2.52,# MassTrade MassTrade is a Windower addon that allows users to quickly trade large quantities of the same item to either a PC or NPC.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/MassTrade/README.md,high
-moveitems,MoveItems,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-myhome,MyHome,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,# MyHome ## English - Automatically choose and uses a warp spell or an item.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/MyHome/README.md,high
-myomen,MyOmen,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,**myomen** - quick way to use your tele ring to get to omen.,https://github.com/Icydeath/ffxi-addons#readme,medium
-nnitimer,NniTimer,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-noknock,noknock,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-omen,Omen,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,**myomen** - quick way to use your tele ring to get to omen.,https://github.com/Icydeath/ffxi-addons#readme,medium
-oneoffs,OneOffs,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-partypets,PartyPets,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-petparty,petparty,ui_gear,Icydeath/ffxi-addons,1,69,1,2.52,# petparty Displays all pet information for your alliance.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/petparty/README.md,high
-positions,Positions,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,"# Positions Windower Addon for positioning mules The two functions of this addon are to have a character follow someone, and to have a character go to their position for fighting an nm.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/Positions/README.md,high
-repeater,Repeater,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,Commands //repeater Gives current settings for repeater.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/Repeater/README.md,high
-roe,roe,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-rolldistance,rolldistance,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,# FFXI Roll Distance Tracks and displays the distance between you and other party members so you know who is in range for your next Phantom Roll.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/rolldistance/README.md,high
-rtfm,rtfm,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,"FFXI Windower Addon rtfm - Read The Freakin' Move Detect, alert and list mob moves as they occur in-game.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/rtfm/README.md,high
-runicportal,RunicPortal,travel,Icydeath/ffxi-addons,1,69,1,2.52,"MagicAssistant (by Valok) : updated //maa help for more info RunicPortal (by icy) : Warping via runic portal, get sanction, get assault tag, get assault orders/armband and more.",https://github.com/Icydeath/ffxi-addons#readme,medium
-schskillchain,schskillchain,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,# schskillchain(ssc) - usage example Open Liquefacrion(溶解) //ssc fire open Close Liquefacrion(溶解) (settable the first letter of parameter) //ssc f c Close Liquefacrion(溶解) and Magic Burst Pyrohelix II (火門の計II) //ssc f c ,https://github.com/Icydeath/ffxi-addons/blob/HEAD/schskillchain/README.md,high
-scriptedextender,ScriptedExtender,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-sendalltarget,SendAllTarget,ui_gear,Icydeath/ffxi-addons,1,69,1,2.52,"Abbreviation: //sat, //sendalltarget Commands: * //sat alltarget - All boxes on this computer target whatever the sender is targetting.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/SendAllTarget/README.md,high
-settarget,SetTarget,ui_gear,Icydeath/ffxi-addons,1,69,1,2.52,Shows enhanced target/enemy HP or status display overlays.,heuristic,low
-simpleassist,SimpleAssist,combat_automation,Icydeath/ffxi-addons,1,69,1,2.52,Keeps your target synced by assisting a chosen party member.,heuristic,low
-sirpopalot,SirPopaLot,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-smarttarget,smarttarget,ui_gear,Icydeath/ffxi-addons,1,69,1,2.52,"smarttarget (by anonymous) : helper addon for targeting specific mobs (ie: dynamis D) stars (by chiaia, modded by me) : yell/shout filter, added the ability to filter specific player names targetplus (pastebin) : //tar -",https://github.com/Icydeath/ffxi-addons#readme,medium
-spellspammer,spellSpammer,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,**spellSpammer** by Lorand - Set the list of spells that you want to spam in file.,https://github.com/Icydeath/ffxi-addons#readme,medium
-stars,Stars,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,# Stars An addon which filters messages based on a filter.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/Stars/README.md,high
-superwarp,superwarp,travel,Icydeath/ffxi-addons,1,69,1,2.52,"**Feature**: An option has been added to check for unlock status of homepoints, waypoints, and survival guides. To enable unlock checks, set the following setting: <enable_locked_warps>false</enable_locked_warps>. This o",https://github.com/Icydeath/ffxi-addons/blob/HEAD/superwarp/README.md,high
-synergy,Synergy,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-targeter,targeter,ui_gear,Icydeath/ffxi-addons,1,69,1,2.52,# FFXI Targeter *Note: This is a work in progress.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/targeter/README.md,high
-targetinfoex,targetinfoEx,ui_gear,Icydeath/ffxi-addons,1,69,1,2.52,"# TargetInfo # This addon shows some memory information of your current target, provided the target is an NPC. This information is otherwise not available in the game. Per settings file adjustable settings: ShowHexID Thi",https://github.com/Icydeath/ffxi-addons/blob/HEAD/targetinfoEx/readme.md,high
-targetplus,TargetPlus,ui_gear,Icydeath/ffxi-addons,1,69,1,2.52,"smarttarget (by anonymous) : helper addon for targeting specific mobs (ie: dynamis D) stars (by chiaia, modded by me) : yell/shout filter, added the ability to filter specific player names targetplus (pastebin) : //tar -",https://github.com/Icydeath/ffxi-addons#readme,medium
-thfknife,ThfKnife,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-tonic,tonic,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,tonic makes it easier to use Escha temp items,https://github.com/Icydeath/ffxi-addons/blob/HEAD/tonic/README.md,high
-trader,Trader,economy_inventory,Icydeath/ffxi-addons,1,69,1,2.52,"Inventory/economy helper for storage, movement, and selling tasks.",heuristic,low
-triggers,triggers,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,tg trigger <string>: Set text trigger.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/triggers/README.md,high
-valkyrie,Valkyrie,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,# Valkyrie A windower addon to streamline Einherjar entry.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/Valkyrie/README.md,high
-voidwalker,voidwalker,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-voidwatch,voidwatch,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-vwpop,VWPop,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-warpmenu,WarpMenu,travel,Icydeath/ffxi-addons,1,69,1,2.52,~~~~~~~~~~~~~ WarpMenu ~~~~~~~~~~~~~ ==================================== *NOTICE* Requires addon: superwarp ==================================== [warpmenu|wm] [window#|win#] [a|add|r|remove] [hp#] [zone name] > auto tra,https://github.com/Icydeath/ffxi-addons/blob/HEAD/WarpMenu/README.md,high
-where,where,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-widescantool,widescantool,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,"Filters: Filters can be useful if widescantool is too cluttered with monsters you do not care about. Fewer entries in the widescan list, and you are less likely to miss something you do care about. Filters can be configu",https://github.com/Icydeath/ffxi-addons/blob/HEAD/widescantool/README.md,high
-woehelper,WoEHelper,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,General FFXI quality-of-life utility addon.,heuristic,low
-xivcrossbar,xivcrossbar,ui_gear,Icydeath/ffxi-addons,1,69,1,2.52,Update Log 01/25/2021 : Added DRGs pet command macros Steps to get XIVCrossbar working: 1) Install Autohotkey (https://www.autohotkey.com/) 2) Run FFXI Configuration tool and set up your gamepad to match ConfigureYourGam,https://github.com/Icydeath/ffxi-addons/blob/HEAD/xivcrossbar/README.md,high
-zenimonsnap,ZenimonSnap,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,ZenimonSnap Automatically equips and uses Soultrapper and Soultrapper 2000 efficiently.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/ZenimonSnap/README.md,high
-zonename,zonename,general_qol,Icydeath/ffxi-addons,1,69,1,2.52,# zonename This addon displays the zone and region name for a short time while changing zones.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/zonename/README.md,high
-ase,ASE,general_qol,Lygre/addons,1,18,1,2.4,General FFXI quality-of-life utility addon.,heuristic,low
-autoinvite,autoinvite,combat_automation,Lygre/addons,1,18,1,2.4,"Abbreviation: //ai, //autoinvite Commands: * <whitelist|blacklist> <add|remove> <player> - adds or removes a player from blacklist or whitelist.",https://github.com/Lygre/addons/blob/HEAD/autoinvite/README.md,high
-broseem,broseem,general_qol,Lygre/addons,1,18,1,2.4,General FFXI quality-of-life utility addon.,heuristic,low
-impalert,ImpAlert,general_qol,Lygre/addons,1,18,1,2.4,General FFXI quality-of-life utility addon.,heuristic,low
-parse,parse,diagnostics,Lygre/addons,1,18,1,2.4,Parses combat logs for damage/performance summaries.,heuristic,low
-petfix,pet_fix,general_qol,Lygre/addons,1,18,1,2.4,General FFXI quality-of-life utility addon.,heuristic,low
-pluginmanager,plugin_manager,general_qol,Lygre/addons,1,18,1,2.4,"2 Click the icon next to ""plugin_manager""",https://github.com/Lygre/addons/blob/HEAD/plugin_manager/README.md,high
-rollbot,RollBot,general_qol,Lygre/addons,1,18,1,2.4,General FFXI quality-of-life utility addon.,heuristic,low
-skilluptracker,skilluptracker,general_qol,Lygre/addons,1,18,1,2.4,skilluptracker [show|hide] [all|craft|magic|combat]:,https://github.com/Lygre/addons/blob/HEAD/skilluptracker/README.md,high
-stna,stna,general_qol,Lygre/addons,1,18,1,2.4,General FFXI quality-of-life utility addon.,heuristic,low
-stopwatch,stopwatch,general_qol,Lygre/addons,1,18,1,2.4,**Commands:** sw start to start the stopwatch sw stop to pause the stopwatch sw reset to reset the stopwatch cumulative time to 0 Addon by Patrick Finnigan (Puhfyn@Ragnarok) - https://github.com/finnigantime.,https://github.com/Lygre/addons/blob/HEAD/stopwatch/readme.md,high
-text,Text,general_qol,Lygre/addons,1,18,1,2.4,General FFXI quality-of-life utility addon.,heuristic,low
-translate,translate,chat_qol,Lygre/addons,1,18,1,2.4,Chat/communication quality-of-life utility.,heuristic,low
-barfiller,barfiller,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-chars,chars,general_qol,mverteuil/windower4-addons,1,17,1,2.39,**fix:** pattern wasn't working with some special chars.,https://github.com/mverteuil/windower4-addons/blob/HEAD/chars/README.md,high
-chatlink,ChatLink,chat_qol,mverteuil/windower4-addons,1,17,1,2.39,Chat/communication quality-of-life utility.,heuristic,low
-enemybar,enemybar,ui_gear,mverteuil/windower4-addons,1,17,1,2.39,# enemybar This is an addon for Windower4 for FFXI.,https://github.com/mverteuil/windower4-addons/blob/HEAD/enemybar/README.md,high
-ffxicaddieprovider,ffxicaddieProvider,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-highlight,highlight,general_qol,mverteuil/windower4-addons,1,17,1,2.39,"##Description This addon highlights the names of the people in your party, and highlights their name when it appears in chat.",https://github.com/mverteuil/windower4-addons/blob/HEAD/highlight/readme.md,high
-inforeplacer,InfoReplacer,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-lazy,Lazy,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-nostrum,Nostrum,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-ohshi,ohShi,general_qol,mverteuil/windower4-addons,1,17,1,2.39,**Abbreviation:** //ohShi **Commands:** 1.,https://github.com/mverteuil/windower4-addons/blob/HEAD/ohShi/Readme.md,high
-plasmon,plasmon,general_qol,mverteuil/windower4-addons,1,17,1,2.39,"**-o _objects_:** specifies the item/s which will have its/their color changed. If this parameter is missing all the objects will be changed. The accepted values are: **all**, **background**, **bg**, **title**, **label**",https://github.com/mverteuil/windower4-addons/blob/HEAD/plasmon/README.md,high
-reive,reive,general_qol,mverteuil/windower4-addons,1,17,1,2.39,"**-o _objects_:** specifies the item/s which will have its/their color changed. If this parameter is missing all the objects will be changed. the accepted values are **all**, **background**, **bg**, **title**, **label**,",https://github.com/mverteuil/windower4-addons/blob/HEAD/reive/README.md,high
-rhombus,Rhombus,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-salvage2,salvage2,general_qol,mverteuil/windower4-addons,1,17,1,2.39,Author: Krizz Version: .5 Date: 20130601 Salvage2 Abbreviation: //s2 Commands: * help - Shows a menu of commands in game * pos <x> <y> - Positions the pathos remaining box.,https://github.com/mverteuil/windower4-addons/blob/HEAD/salvage2/README.md,high
-satacast,SATACast,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-setbgm,setbgm,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-strathelper,StratHelper,general_qol,mverteuil/windower4-addons,1,17,1,2.39,StratHelper ===== StratHelper is a simple helper addon for Spellcast for Scholar Stratagems.,https://github.com/mverteuil/windower4-addons/blob/HEAD/StratHelper/Readme.md,high
-taps,taps,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-targetinfo,targetinfo,ui_gear,mverteuil/windower4-addons,1,17,1,2.39,"# TargetInfo # This addon shows some memory information of your current target, provided the target is an NPC.",https://github.com/mverteuil/windower4-addons/blob/HEAD/targetinfo/readme.md,high
-truesight,truesight,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-visiblefavor,VisibleFavor,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-yush,Yush,general_qol,mverteuil/windower4-addons,1,17,1,2.39,General FFXI quality-of-life utility addon.,heuristic,low
-allseeingeye,allseeingeye,general_qol,Icydeath/ffxi-addons; ProjectTako/ffxi-addons,2,99,2,2.15,# ffxi-addons/allseeingeye AllSeeingEyes: This was popularized long ago from the Windower 3.x plugin with the same name.,https://github.com/ProjectTako/ffxi-addons/blob/HEAD/allseeingeye/README.md,high
-equipviewer,equipviewer,ui_gear,Icydeath/ffxi-addons; ProjectTako/ffxi-addons,2,99,2,2.15,# ffxi-addons/equipviewer EquipViewer: Overlays your currently equipped items onto the screen anywhere.,https://github.com/ProjectTako/ffxi-addons/blob/HEAD/equipviewer/README.md,high
-partybuffs,partybuffs,ui_gear,Lygre/addons; ProjectTako/ffxi-addons,2,99,2,2.15,# ffxi-addons/partybuffs An addon made from https://github.com/KenshiDRK/Addons/tree/master/PartyBuffs for Ashita.,https://github.com/ProjectTako/ffxi-addons/blob/HEAD/partybuffs/README.md,high
-react,react,combat_automation,Icydeath/ffxi-addons; ProjectTako/ffxi-addons,2,99,2,2.15,"# ffxi-addons/react React: Based on the Windower addon by Sammeh (https://github.com/SammehFFXI/FFXIAddons/tree/master/React), works very similar.",https://github.com/ProjectTako/ffxi-addons/blob/HEAD/react/README.md,high
-autocor,AutoCOR,combat_automation,Icydeath/ffxi-addons; Ivaar/Windower-addons,2,79,2,2.1,"Accepts auto-translate terms, not case-sensitive. ""//cor [on|off]"" ""//cor roll <n> <job|roll_name>"" -- set roll ""//cor cc [n|off]"" -- Use crooked cards on roll [n] (default is 1st roll, 0 is off) ""//cor aoe <slot|party> ",https://github.com/Ivaar/Windower-addons/blob/HEAD/AutoCOR/README.md,high
-autogeo,AutoGEO,combat_automation,Icydeath/ffxi-addons; Ivaar/Windower-addons,2,79,2,2.1,"Some have been modified by me to suit my own needs, full credit goes to the original creators._ **allseeingeye** by Project Tako **AllWarps** by Ivaar - Gives access to the menu options for the following warps: Homepoint",https://github.com/Icydeath/ffxi-addons#readme,medium
-chatman,ChatMan,chat_qol,Icydeath/ffxi-addons; Ivaar/Windower-addons,2,79,2,2.1,ChatManager ============= Alternative to chatmon.,https://github.com/Ivaar/Windower-addons/blob/HEAD/ChatMan/README.md,high
-htmb,htmb,general_qol,Icydeath/ffxi-addons; Ivaar/Windower-addons,2,79,2,2.1,"//htmb - When near one of the KI NPCs, it will buy the KI\'s you have set.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/htmb/README.md,high
-porterpacker,PorterPacker,economy_inventory,Icydeath/ffxi-addons; Ivaar/Windower-addons,2,79,2,2.1,# PorterPacker ### Commands: command|alias [optional] //porterpacker or //packer or //po,https://github.com/Ivaar/Windower-addons/blob/HEAD/PorterPacker/README.md,high
-singer,Singer,combat_automation,Icydeath/ffxi-addons; Ivaar/Windower-addons,2,79,2,2.1,# Sing ### Automates casting of bard buff songs. #### If you are updating from a version prior to 1.20.05.09 make sure you delete your existing settings.xml file located within the addons data folder. Configure songs wit,https://github.com/Ivaar/Windower-addons/blob/HEAD/Singer/README.md,high
-tradenpc,TradeNPC,economy_inventory,Icydeath/ffxi-addons; Ivaar/Windower-addons,2,79,2,2.1,# TradeNPC Trade an npc up to 8 stacks of items and gil with a single command.,https://github.com/Ivaar/Windower-addons/blob/HEAD/TradeNPC/README.md,high
-magicassistant,MagicAssistant,combat_automation,Icydeath/ffxi-addons; ValokAsura/WindowerAddons,2,69,2,2.07,"**SurvivalGuide** by SammehFFXI - //sg warp <zone> , soft-locks use //terminate **unm** by Darkdoom **MagicAssistant** by [Valok] -Automated magic bursting script //maa nap [spell/helix/ga/ja/ra/nin] [tier] **tonic** - u",https://github.com/Icydeath/ffxi-addons#readme,medium
-quicktrade,QuickTrade,economy_inventory,Icydeath/ffxi-addons; ValokAsura/WindowerAddons,2,69,2,2.07,Geas Fete: Key Item detection added. QuickTrade will not try to trade for a Key Item you already posses.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/QuickTrade/readme.md,high
-sendtarget,SendTarget,ui_gear,DiscipleOfEris/Windower4Addons; Icydeath/ffxi-addons,2,69,2,2.07,# SendTarget FFXI Windower addon that allows multiboxers to more easily send commands.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/SendTarget/README.md,high
-anchor,anchor,general_qol,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,"Some have been modified by me to suit my own needs, full credit goes to the original creators._ **allseeingeye** by Project Tako **AllWarps** by Ivaar - Gives access to the menu options for the following warps: Homepoint",https://github.com/Icydeath/ffxi-addons#readme,medium
-autocontrol,autocontrol,combat_automation,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,"**Abbreviations:** acon, autocontrol **Commands:** 1.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/autocontrol/readme.md,high
-autojoin,autojoin,combat_automation,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,"# AutoJoin Once loaded, will automatically join party and alliance invites.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/autojoin/readme.md,high
-autows,AutoWS,combat_automation,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,Automates repeated job or combat actions with rule-based logic.,heuristic,low
-azuresets,azureSets,general_qol,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,"**Author:** Ricky Gall **Version:** 1.24 **Description:** Addon to make setting blue spells easier. Currently only works as blu main. **Abbreviations:** aset, azureset **Commands:** 1. //aset removeall - Unsets all spell",https://github.com/Icydeath/ffxi-addons/blob/HEAD/azureSets/Readme.md,high
-clock,Clock,general_qol,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,General FFXI quality-of-life utility addon.,heuristic,low
-dostuff,dostuff,general_qol,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,'dos delay': Specify delay (default is 5 secs). This can be adjusted while dostuff is running if needed.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/dostuff/README.md,high
-dynamishelper,dynamishelper,general_qol,Icydeath/ffxi-addons; mverteuil/windower4-addons,2,69,1,1.72,Authors: Krizz Version: 1 Date: 20130419 Dynamis Helper Abbreviation: //dh Commands: * help - Shows a menu of commands in game * timer [on/off] - Displays a timer each time a mob is staggered.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/dynamishelper/README.md,high
-fisher,fisher,general_qol,Icydeath/ffxi-addons; mverteuil/windower4-addons,2,69,1,1.72,Fisher will always confuse 1 gil and 100 gil.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/fisher/README.md,high
-lottery,lottery,general_qol,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,General FFXI quality-of-life utility addon.,heuristic,low
-macrochanger,macrochanger,general_qol,Icydeath/ffxi-addons; mverteuil/windower4-addons,2,69,1,1.72,General FFXI quality-of-life utility addon.,heuristic,low
-porter,porter,economy_inventory,Icydeath/ffxi-addons; mverteuil/windower4-addons,2,69,1,1.72,"**add**: New command, porter find.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/porter/README.md,high
-send,send,general_qol,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,"## Usage The target can be the receiver's name, @all to send to all instances, @other to send to all instances excluding the sender or @<job> to send to a specific job.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/send/readme.md,high
-silence,Silence,general_qol,Icydeath/ffxi-addons; mverteuil/windower4-addons,2,69,1,1.72,"Use the line ""silence mode 0"" to not allow any lines to go through.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/Silence/readme.md,high
-subtarget,SubTarget,ui_gear,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,"name = 'SubTarget' version = '1.0' author = 'Sebyg666' Must have the ""send"" addon to work can use //subtarget or //sta Command ""HELP"" or no command: Explanation of the addons usage printed to the console, essentially the",https://github.com/Icydeath/ffxi-addons/blob/HEAD/SubTarget/README.txt,high
-thtracker,thtracker,general_qol,Icydeath/ffxi-addons; mverteuil/windower4-addons,2,69,1,1.72,Authors: Krizz Version: 1.0 Date: 20170509 TH Tracker Abbreviation: //th Commands: * help - Shows a menu of commands in game * pos x y - Positions the TH box.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/thtracker/readme.md,high
-timestamp,timestamp,chat_qol,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,"**_format_:** defines the timestamp's format. The available constants are: **${year}**, **${y}**, **${year_short}**, **${month}**, **${m}**, **${month_short}**, **${month_long}**, **${day}**, **${d}**, **${day_short}**, ",https://github.com/Icydeath/ffxi-addons/blob/HEAD/timestamp/README.md,high
-treasurepool,TreasurePool,general_qol,Icydeath/ffxi-addons; Lygre/addons,2,69,1,1.72,General FFXI quality-of-life utility addon.,heuristic,low
-autosynth,autoSynth,combat_automation,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,Automates repeated job or combat actions with rule-based logic.,heuristic,low
-bluguide,bluguide,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-boxdestroyer,boxdestroyer,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-debuffed,Debuffed,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-digger,digger,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-distance,distance,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,# Distance Emulates the functionality of the Distance plugin.,https://github.com/mverteuil/windower4-addons/blob/HEAD/distance/readme.md,high
-gametime,gametime,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-instals,instaLS,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-latentchecker,latentchecker,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-linker,linker,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,"# Linker Opens certain links via simple console commands, with an optional search string.",https://github.com/mverteuil/windower4-addons/blob/HEAD/linker/readme.md,high
-ohnoyoudont,OhNoYouDont,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-opensesame,OpenSesame,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-packetviewer,PacketViewer,diagnostics,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,"Diagnostic utility for logs, packets, or runtime behavior visibility.",heuristic,low
-pettp,PetTP,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-pricer,Pricer,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-rolltracker,rolltracker,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,"If you have rolled a lucky roll, it will also prompt you and automatically stop you from doubling up on it (which can be bypassed by either doubling up again, or typing //rolltracker autostop Enjoy.",https://github.com/mverteuil/windower4-addons/blob/HEAD/rolltracker/readme.md,high
-scoreboard,scoreboard,ui_gear,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,"UI enhancement for combat, targeting, or gear visibility.",heuristic,low
-skillchain,Skillchain,combat_automation,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,Displays skillchain options/windows and timing during combat.,heuristic,low
-speedchecker,SpeedChecker,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-spellcheck,SpellCheck,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,#SpellCheck This addon lists spells you haven't unlocked yet.,https://github.com/mverteuil/windower4-addons/blob/HEAD/SpellCheck/README.md,high
-sprint,Sprint,travel,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,Travel quality-of-life helper for warps and navigation.,heuristic,low
-synthall,synthall,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,General FFXI quality-of-life utility addon.,heuristic,low
-update,update,general_qol,Lygre/addons; mverteuil/windower4-addons,2,18,1,1.6,# Update Once loaded can update all addons and plugins to the newest version using //update.,https://github.com/mverteuil/windower4-addons/blob/HEAD/update/readme.md,high
-fastcs,fastcs,general_qol,Icydeath/ffxi-addons; Lygre/addons; ProjectTako/ffxi-addons; mverteuil/windower4-addons,4,99,2,1.35,# ffxi-addons/fastcs FastCS: FastCS is an addon based on the Windower4 addon with the same name.,https://github.com/ProjectTako/ffxi-addons/blob/HEAD/fastcs/README.md,high
-auctionhelper,AuctionHelper,economy_inventory,Icydeath/ffxi-addons; Ivaar/Windower-addons; Lygre/addons,3,79,2,1.3,"AuctionHelper ============= Auction house bidding tool - addon for Windower ----------------------------------------------- Allows you to perform auction house actions with commands, much like bidder with additional func",https://github.com/Ivaar/Windower-addons/blob/HEAD/AuctionHelper/README.md,high
-sellnpc,SellNPC,economy_inventory,Icydeath/ffxi-addons; Ivaar/Windower-addons; Lygre/addons; mverteuil/windower4-addons,4,79,2,1.3,"# SellNPC ### Command Usage: Sales are now triggered by opening a shop window, you will need to queue items prior to this.",https://github.com/Ivaar/Windower-addons/blob/HEAD/SellNPC/README.md,high
-trade,Trade,economy_inventory,Icydeath/ffxi-addons; Ivaar/Windower-addons; Lygre/addons,3,79,2,1.3,# Trade #### Accepts trade requests and confirms from whitelisted players.,https://github.com/Ivaar/Windower-addons/blob/HEAD/Trade/README.md,high
-aecho,aecho,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,General FFXI quality-of-life utility addon.,heuristic,low
-autora,AutoRA,combat_automation,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,2.0.0 AutoRA simply causes ranged attacks to behave like the melee Auto-Attack while your weapon is drawn.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/AutoRA/README.md,high
-battlemod,battlemod,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,unload - unloads Battlemod,https://github.com/Icydeath/ffxi-addons/blob/HEAD/battlemod/README.md,high
-cancel,cancel,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,General FFXI quality-of-life utility addon.,heuristic,low
-consolebg,ConsoleBG,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,General FFXI quality-of-life utility addon.,heuristic,low
-dressup,DressUp,ui_gear,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,Applies visual appearance/style overrides.,heuristic,low
-enternity,enternity,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,"**Author:** Giuliano Riccio **Version:** v 1.20131102 # Enternity # Enters ""Enter"" automatically when prompted during a cutscene or when talking to NPCs.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/enternity/README.md,high
-eval,eval,diagnostics,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,Author: Aureus Version: 1.0 Addon to evaluate lua code via windower commands Abbreviation: //eval Use //eval to run arbitrary lua code.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/eval/readme.md,high
-findall,findAll,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,# FindAll This addon searches items stored on all your characters.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/findAll/README.md,high
-gearswap,GearSwap,ui_gear,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,"PLEASE DO NOT MESSAGE ME ABOUT ANYTHING THIRD PARTY IN GAME, however feel free to send me a way to contact you outside of game, through the game, and I'm happy to help, my preferred way of being contact is Discord, my St",https://github.com/Icydeath/ffxi-addons/blob/HEAD/GearSwap/README.md,high
-healbot,HealBot,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,To load healBot: //lua load healbot,https://github.com/Icydeath/ffxi-addons/blob/HEAD/HealBot/readme.md,high
-invspace,InvSpace,economy_inventory,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,Edit the buy_list in file **InvSpace** by Kenshi - Shows each inventory containers free space in a moveable box **Juggler** by psykad - Juggler is to simplify the use of Ready commands for jug pets **lazyMB** by kotodama,https://github.com/Icydeath/ffxi-addons#readme,medium
-itemizer,itemizer,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,#Itemizer Provides a chat/console interface for moving items around between bags.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/itemizer/readme.md,high
-logger,Logger,diagnostics,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,"Diagnostic utility for logs, packets, or runtime behavior visibility.",heuristic,low
-organizer,organizer,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,General FFXI quality-of-life utility addon.,heuristic,low
-pointwatch,pointwatch,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,General FFXI quality-of-life utility addon.,heuristic,low
-pouches,Pouches,economy_inventory,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,"Inventory/economy helper for storage, movement, and selling tasks.",heuristic,low
-shortcuts,shortcuts,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,"#Shortcuts v2.9 ####written by Byrth Completes and properly formats commands (prefixed by at least one '/'), including emotes and checks.",https://github.com/Icydeath/ffxi-addons/blob/HEAD/shortcuts/readme.md,high
-skillchains,Skillchains,combat_automation,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,# SkillChains ### Active Battle Skillchain Display.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/Skillchains/README.md,high
-sparks,Sparks,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,"**unm** - Updated to Darkdoom's v2, further modified the script to include the force option; which allows the player to continue to pop the unm even if sparks are capped.",https://github.com/Icydeath/ffxi-addons#readme,medium
-tparty,TParty,ui_gear,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,"UI enhancement for combat, targeting, or gear visibility.",heuristic,low
-treasury,Treasury,economy_inventory,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,Automates treasure pool lot/pass/drop decisions.,heuristic,low
-zonetimer,zonetimer,general_qol,Icydeath/ffxi-addons; Lygre/addons; mverteuil/windower4-addons,3,69,1,0.92,Commands: zonetimer posX # change the x position zonetimer posY # change the y position zonetimer fontsize # change the fontsize zoentimer help print these instructions in the log Original plugin by Krellion.,https://github.com/Icydeath/ffxi-addons/blob/HEAD/zonetimer/readme.md,high
+xipivot,XIpivot,general_qol,HealsCodes/XIPivot,1,61,5,4.83,FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs,https://github.com/HealsCodes/XIPivot,medium
+trust,Trust,automation,cyritegamestudios/trust,1,49,5,4.83,Windower 4 addon for FFXI to automate your character in battle.,https://github.com/cyritegamestudios/trust,medium
+xivparty,XIvparty,ui_gear,Tylas11/XivParty,1,47,5,4.83,A party list addon for Windower 4.,https://github.com/Tylas11/XivParty,medium
+atreplace,Atreplace,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+augments,Augments,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+chatfix,Chatfix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+clevel,Clevel,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+collector,Collector,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+dramagen,Dramagen,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+gilbox,Gilbox,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+indinope,Indinope,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+jobinit,Jobinit,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+kaomoji,Kaomoji,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+menufix,Menufix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+mousehalo,Mousehalo,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+ondemand,Ondemand,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+position_manager,Position Manager,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+readable,Readable,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+safeoboro,Safeoboro,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+silttracker,Silttracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+smeagol,Smeagol,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+special,Special,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+tellapart,Tellapart,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+tellfix,Tellfix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+tiptoes,Tiptoes,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+tpsreport,Tpsreport,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+trialtracker,Trialtracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+useall,Useall,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+waveback,Waveback,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+weathermon,Weathermon,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+witnessprotection,Witnessprotection,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+bluspells,Bluspells,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+chatty,Chatty,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+colure,Colure,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+dxui,Dxui,ui_gear,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+imrecast,Imrecast,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+loggers,Loggers,diagnostics,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+minimap-helper,Minimap Helper,automation,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+rcheck,Rcheck,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+relicge,Relicge,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+repl,Repl,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+strats,Strats,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+trials,Trials,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+wheel,Wheel,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+xitools,XItools,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+attend,Attend,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+bars,Bars,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+battleplan,Battleplan,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+callouts,Callouts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+emotes,Emotes,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+exorcist,Exorcist,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+gaolplan,Gaolplan,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+helper,Helper,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+informer,Informer,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+jingle,Jingle,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+leaderboard,Leaderboard,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+llmchat,Llmchat,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+readycheck,Readycheck,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+sweeper,Sweeper,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+taskbar,Taskbar,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+vanafacts,Vanafacts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+vanapad,Vanapad,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+vanity,Vanity,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+znmtracker,Znmtracker,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+addons,Addons,diagnostics,HealsCodes/statustimers,1,15,5,4.83,Statustimers for Ashita v4,https://github.com/HealsCodes/statustimers,medium
+ffxi-zonename,FFXI Zonename,travel_navigation,onimitch/ffxi-zonename,1,4,5,4.83,This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.,https://github.com/onimitch/ffxi-zonename,medium
+xichecklist,XIchecklist,travel_navigation,HiPotionQ8/XIchecklist,1,4,5,4.83,"windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",https://github.com/HiPotionQ8/XIchecklist,medium
+tourist,Tourist,travel_navigation,Bryenne-Sylph/tourist,1,3,5,4.83,An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ,https://github.com/Bryenne-Sylph/tourist,medium
+gmtools,Gmtools,automation,SQLCommit/GMTools,1,2,5,4.83,FFXI - Ashita v4.3 Addon - LSB GM Command Helper,https://github.com/SQLCommit/GMTools,medium
+lootscope,Lootscope,economy_inventory,SQLCommit/LootScope,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Loot Drop Tracker,https://github.com/SQLCommit/LootScope,medium
+memscope,Memscope,diagnostics,SQLCommit/MemScope,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage,https://github.com/SQLCommit/MemScope,medium
+zonelines,Zonelines,travel_navigation,SQLCommit/ZoneLines,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Zone Line Visualizer,https://github.com/SQLCommit/ZoneLines,medium
+debuff-tracker,Debuff Tracker,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+menus,Menus,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+scanzone,Scanzone,travel_navigation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+turnaround,Turnaround,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+autodnc,Autodnc,automation,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+chococard,Chococard,general_qol,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+questlog,Questlog,general_qol,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+packetviewerlogviewer,Packetviewerlogviewer,diagnostics,ZeromusXYZ/PacketViewerLogViewer,1,17,2,3.78,PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp,https://github.com/ZeromusXYZ/PacketViewerLogViewer,medium
+ui,Ui,ui_gear,AliekberFFXI/xivcrossbar,1,17,2,3.78,FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar,https://github.com/AliekberFFXI/xivcrossbar,medium
+bursting,Bursting,general_qol,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
+crystaltrader,Crystaltrader,economy_inventory,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
+quicktrade_2,Quicktrade 2,ui_gear,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
+autoassist,Autoassist,automation,ekrividus/autoAssist,1,13,2,3.78,An ffxi windower addon to automatically assist a party member in combat,https://github.com/ekrividus/autoAssist,medium
+xivhotbar2,XIvhotbar2,ui_gear,Technyze/XIVHotbar2,1,13,2,3.78,,,low
+assist,Assist,automation,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+eradebuffed,Eradebuffed,combat_automation,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+eradistanceplus,Eradistanceplus,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+erainfobar,Erainfobar,ui_gear,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+erajobchange,Erajobchange,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+eramobdrops,Eramobdrops,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+eramoblevel,Eramoblevel,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+erapointwatch,Erapointwatch,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+erascoreboard,Erascoreboard,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+fastfollow,Fastfollow,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+clickfind,Clickfind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+dupefind,Dupefind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+friendzone,Friendzone,travel_navigation,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+omen,Omen,general_qol,Icydeath/ffxi-addons;mousseng/xitools,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+posfind,Posfind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+statsearch,Statsearch,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+superwarp,Superwarp,travel_navigation,AkadenTK/superwarp;Icydeath/ffxi-addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+ambuloot,Ambuloot,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+attackid,Attackid,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+attackwithme,Attackwithme,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autochain,Autochain,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autopup,Autopup,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autoraise,Autoraise,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autoskillchain,Autoskillchain,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autounm,Autounm,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autovw,Autovw,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autowatch,Autowatch,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+blist,Blist,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+canteen,Canteen,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+capetrader,Capetrader,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+charmed,Charmed,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+checkparam,Checkparam,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+crb_addon,Crb Addon,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+cureplease_addon,Cureplease Addon,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+currencies,Currencies,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+distanceplus,Distanceplus,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+drop,Drop,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+eschachest,Eschachest,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+export_items,Export Items,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+ffxikeys,FFXIkeys,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+finalalert,Finalalert,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+followme,Followme,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+giltracker,Giltracker,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+jobchange,Jobchange,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+locke,Locke,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+lockpick,Lockpick,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+maga,Maga,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+masstrade,Masstrade,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+moveitems,Moveitems,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+myhome,Myhome,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+myomen,Myomen,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+nnitimer,Nnitimer,diagnostics,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+noknock,Noknock,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+oneoffs,Oneoffs,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+partypets,Partypets,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+petparty,Petparty,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+positions,Positions,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+repeater,Repeater,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+roe,Roe,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+rolldistance,Rolldistance,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+rtfm,Rtfm,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+runicportal,Runicportal,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+schskillchain,Schskillchain,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+scriptedextender,Scriptedextender,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+sendalltarget,Sendalltarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+settarget,Settarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+simpleassist,Simpleassist,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+sirpopalot,Sirpopalot,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+smarttarget,Smarttarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+spellspammer,Spellspammer,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+stars,Stars,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+synergy,Synergy,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+targeter,Targeter,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+targetinfoex,Targetinfoex,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+targetplus,Targetplus,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+thfknife,Thfknife,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+tonic,Tonic,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+trader,Trader,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+triggers,Triggers,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+valkyrie,Valkyrie,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+voidwalker,Voidwalker,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+voidwatch,Voidwatch,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+vwpop,Vwpop,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+warpmenu,Warpmenu,travel_navigation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+where,Where,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+widescantool,Widescantool,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+woehelper,Woehelper,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+xivcrossbar,XIvcrossbar,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+zenimonsnap,Zenimonsnap,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+zonename,Zonename,travel_navigation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+enemybar2,Enemybar2,ui_gear,AkadenTK/enemybar2,1,19,1,3.43,Evolution of the simpler Windower addon that displays a target health bar prominently onscreen,https://github.com/AkadenTK/enemybar2,medium
+ase,Ase,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+autoinvite,Autoinvite,automation,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+broseem,Broseem,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+impalert,Impalert,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+pet_fix,Pet Fix,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+plugin_manager,Plugin Manager,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+rollbot,Rollbot,automation,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+skilluptracker,Skilluptracker,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+stna,Stna,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+stopwatch,Stopwatch,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+text,Text,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+translate,Translate,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+xivhotbar,XIvhotbar,ui_gear,Akirane/XIVHotbar,1,18,1,3.43,,,low
+barfiller,Barfiller,ui_gear,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+chars,Chars,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+chatlink,Chatlink,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+enemybar,Enemybar,ui_gear,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+ffxicaddieprovider,FFXIcaddieprovider,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+highlight,Highlight,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+inforeplacer,Inforeplacer,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+lazy,Lazy,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+nostrum,Nostrum,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+ohshi,Ohshi,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+plasmon,Plasmon,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+reive,Reive,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+rhombus,Rhombus,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+salvage2,Salvage2,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+satacast,Satacast,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+setbgm,Setbgm,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+strathelper,Strathelper,automation,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+taps,Taps,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+targetinfo,Targetinfo,combat_automation,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+truesight,Truesight,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+visiblefavor,Visiblefavor,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+yush,Yush,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+skillchain,Skillchain,combat_automation,Lygre/addons;mousseng/xitools;mverteuil/windower4-addons,3,29,5,3.26,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+allseeingeye,Allseeingeye,general_qol,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+equipviewer,Equipviewer,automation,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+partybuffs,Partybuffs,automation,Lygre/addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+react,React,automation,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+autocor,Autocor,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+autogeo,Autogeo,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+chatman,Chatman,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+htmb,Htmb,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+porterpacker,Porterpacker,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+singer,Singer,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+tradenpc,Tradenpc,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+magicassistant,Magicassistant,automation,Icydeath/ffxi-addons;ValokAsura/WindowerAddons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+quicktrade,Quicktrade,ui_gear,Icydeath/ffxi-addons;ValokAsura/WindowerAddons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+sendtarget,Sendtarget,combat_automation,DiscipleOfEris/Windower4Addons;Icydeath/ffxi-addons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+parse,Parse,diagnostics,Lygre/addons;flippant/parse,2,18,2,2.66,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+anchor,Anchor,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autocontrol,Autocontrol,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autojoin,Autojoin,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autows,Autows,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+azuresets,Azuresets,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+clock,Clock,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+dostuff,Dostuff,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+dynamishelper,Dynamishelper,automation,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+fisher,Fisher,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+lottery,Lottery,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+macrochanger,Macrochanger,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+porter,Porter,economy_inventory,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+send,Send,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+silence,Silence,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+subtarget,Subtarget,combat_automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+thtracker,Thtracker,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+timestamp,Timestamp,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+treasurepool,Treasurepool,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autosynth,Autosynth,automation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+bluguide,Bluguide,travel_navigation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+boxdestroyer,Boxdestroyer,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+debuffed,Debuffed,combat_automation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+digger,Digger,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+distance,Distance,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+gametime,Gametime,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+instals,Instals,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+latentchecker,Latentchecker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+linker,Linker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+ohnoyoudont,Ohnoyoudont,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+opensesame,Opensesame,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+packetviewer,Packetviewer,diagnostics,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+pettp,Pettp,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+pricer,Pricer,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+rolltracker,Rolltracker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+scoreboard,Scoreboard,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+speedchecker,Speedchecker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+spellcheck,Spellcheck,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+sprint,Sprint,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+synthall,Synthall,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+update,Update,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+skillchains,Skillchains,combat_automation,Icydeath/ffxi-addons;Ivaar/Skillchains;Lygre/addons;mverteuil/windower4-addons,4,69,3,2.27,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low
+auctionhelper,Auctionhelper,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons,3,79,2,2.21,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+trade,Trade,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons,3,79,2,2.21,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+fastcs,Fastcs,general_qol,Icydeath/ffxi-addons;Lygre/addons;ProjectTako/ffxi-addons;mverteuil/windower4-addons,4,99,2,1.92,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,low
+sellnpc,Sellnpc,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons;mverteuil/windower4-addons,4,79,2,1.92,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,low
+aecho,Aecho,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autora,Autora,automation,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+battlemod,Battlemod,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+cancel,Cancel,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+consolebg,Consolebg,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+dressup,Dressup,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+enternity,Enternity,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+eval,Eval,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+findall,Findall,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+gearswap,Gearswap,ui_gear,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+invspace,Invspace,economy_inventory,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+itemizer,Itemizer,economy_inventory,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+logger,Logger,diagnostics,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+organizer,Organizer,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+pointwatch,Pointwatch,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+pouches,Pouches,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+shortcuts,Shortcuts,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+sparks,Sparks,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+tparty,Tparty,ui_gear,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+treasury,Treasury,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+zonetimer,Zonetimer,travel_navigation,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+healbot,Healbot,automation,Icydeath/ffxi-addons;Lygre/addons;lorand-ffxi/HealBot;mverteuil/windower4-addons,4,69,1,1.57,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low

--- a/ffxi-addon-catalog-normalized.json
+++ b/ffxi-addon-catalog-normalized.json
@@ -1,7 +1,7 @@
 [
   {
     "addon_key": "xipivot",
-    "addon_name": "XIPivot",
+    "addon_name": "XIpivot",
     "category": "general_qol",
     "repos": [
       "HealsCodes/XIPivot"
@@ -9,14 +9,14 @@
     "repo_count": 1,
     "best_repo_stars": 61,
     "freshness_max": 5,
-    "opportunity_score": 4.3,
+    "opportunity_score": 4.83,
     "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
     "description_source": "https://github.com/HealsCodes/XIPivot",
     "description_confidence": "medium"
   },
   {
     "addon_key": "trust",
-    "addon_name": "trust",
+    "addon_name": "Trust",
     "category": "automation",
     "repos": [
       "cyritegamestudios/trust"
@@ -24,9 +24,969 @@
     "repo_count": 1,
     "best_repo_stars": 49,
     "freshness_max": 5,
-    "opportunity_score": 4.26,
+    "opportunity_score": 4.83,
     "description": "Windower 4 addon for FFXI to automate your character in battle.",
     "description_source": "https://github.com/cyritegamestudios/trust",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xivparty",
+    "addon_name": "XIvparty",
+    "category": "ui_gear",
+    "repos": [
+      "Tylas11/XivParty"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 47,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "A party list addon for Windower 4.",
+    "description_source": "https://github.com/Tylas11/XivParty",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "atreplace",
+    "addon_name": "Atreplace",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "augments",
+    "addon_name": "Augments",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatfix",
+    "addon_name": "Chatfix",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "clevel",
+    "addon_name": "Clevel",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "collector",
+    "addon_name": "Collector",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dramagen",
+    "addon_name": "Dramagen",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "gilbox",
+    "addon_name": "Gilbox",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "indinope",
+    "addon_name": "Indinope",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "jobinit",
+    "addon_name": "Jobinit",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "kaomoji",
+    "addon_name": "Kaomoji",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "menufix",
+    "addon_name": "Menufix",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "mousehalo",
+    "addon_name": "Mousehalo",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ondemand",
+    "addon_name": "Ondemand",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "position_manager",
+    "addon_name": "Position Manager",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "readable",
+    "addon_name": "Readable",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "safeoboro",
+    "addon_name": "Safeoboro",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "silttracker",
+    "addon_name": "Silttracker",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "smeagol",
+    "addon_name": "Smeagol",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "special",
+    "addon_name": "Special",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tellapart",
+    "addon_name": "Tellapart",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tellfix",
+    "addon_name": "Tellfix",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tiptoes",
+    "addon_name": "Tiptoes",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tpsreport",
+    "addon_name": "Tpsreport",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trialtracker",
+    "addon_name": "Trialtracker",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "useall",
+    "addon_name": "Useall",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "waveback",
+    "addon_name": "Waveback",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "weathermon",
+    "addon_name": "Weathermon",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "witnessprotection",
+    "addon_name": "Witnessprotection",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "bluspells",
+    "addon_name": "Bluspells",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatty",
+    "addon_name": "Chatty",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "colure",
+    "addon_name": "Colure",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dxui",
+    "addon_name": "Dxui",
+    "category": "ui_gear",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "imrecast",
+    "addon_name": "Imrecast",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "loggers",
+    "addon_name": "Loggers",
+    "category": "diagnostics",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "minimap-helper",
+    "addon_name": "Minimap Helper",
+    "category": "automation",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "rcheck",
+    "addon_name": "Rcheck",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "relicge",
+    "addon_name": "Relicge",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "repl",
+    "addon_name": "Repl",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "strats",
+    "addon_name": "Strats",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trials",
+    "addon_name": "Trials",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "wheel",
+    "addon_name": "Wheel",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xitools",
+    "addon_name": "XItools",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "attend",
+    "addon_name": "Attend",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "bars",
+    "addon_name": "Bars",
+    "category": "ui_gear",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "battleplan",
+    "addon_name": "Battleplan",
+    "category": "automation",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "callouts",
+    "addon_name": "Callouts",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "emotes",
+    "addon_name": "Emotes",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "exorcist",
+    "addon_name": "Exorcist",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "gaolplan",
+    "addon_name": "Gaolplan",
+    "category": "automation",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "helper",
+    "addon_name": "Helper",
+    "category": "automation",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "informer",
+    "addon_name": "Informer",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "jingle",
+    "addon_name": "Jingle",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "leaderboard",
+    "addon_name": "Leaderboard",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "llmchat",
+    "addon_name": "Llmchat",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "readycheck",
+    "addon_name": "Readycheck",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "sweeper",
+    "addon_name": "Sweeper",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "taskbar",
+    "addon_name": "Taskbar",
+    "category": "ui_gear",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanafacts",
+    "addon_name": "Vanafacts",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanapad",
+    "addon_name": "Vanapad",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanity",
+    "addon_name": "Vanity",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "znmtracker",
+    "addon_name": "Znmtracker",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "addons",
+    "addon_name": "Addons",
+    "category": "diagnostics",
+    "repos": [
+      "HealsCodes/statustimers"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 15,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Statustimers for Ashita v4",
+    "description_source": "https://github.com/HealsCodes/statustimers",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ffxi-zonename",
+    "addon_name": "FFXI Zonename",
+    "category": "travel_navigation",
+    "repos": [
+      "onimitch/ffxi-zonename"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 4,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.",
+    "description_source": "https://github.com/onimitch/ffxi-zonename",
     "description_confidence": "medium"
   },
   {
@@ -39,14 +999,14 @@
     "repo_count": 1,
     "best_repo_stars": 4,
     "freshness_max": 5,
-    "opportunity_score": 3.89,
+    "opportunity_score": 4.83,
     "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
     "description_source": "https://github.com/HiPotionQ8/XIchecklist",
     "description_confidence": "medium"
   },
   {
     "addon_key": "tourist",
-    "addon_name": "tourist",
+    "addon_name": "Tourist",
     "category": "travel_navigation",
     "repos": [
       "Bryenne-Sylph/tourist"
@@ -54,434 +1014,434 @@
     "repo_count": 1,
     "best_repo_stars": 3,
     "freshness_max": 5,
-    "opportunity_score": 3.85,
+    "opportunity_score": 4.83,
     "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
     "description_source": "https://github.com/Bryenne-Sylph/tourist",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "atreplace",
-    "addon_name": "atreplace",
-    "category": "general_qol",
+    "addon_key": "gmtools",
+    "addon_name": "Gmtools",
+    "category": "automation",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "SQLCommit/GMTools"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
+    "best_repo_stars": 2,
     "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "For more details: https://www.ffxiah.com/forum/topic/58154/atreplace-autotranslate-in-scripts-and-aliases/ _**USE THIS AT YOUR OWN RISK**_, I did my best to make sure it copied client behavior 100% but it's entirely poss",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/atreplace/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "augments",
-    "addon_name": "augments",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "augments: search items by name and print their augments to chatlog. If you need to know how many Chironic Hoses you own, and what their augments are.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - LSB GM Command Helper",
+    "description_source": "https://github.com/SQLCommit/GMTools",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "chatfix",
-    "addon_name": "chatfix",
-    "category": "chat_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "create a windowerfolder\\addons\\chatfix folder, and put chatfix.lua there",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/chatfix/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "clevel",
-    "addon_name": "clevel",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "clevel: prints your current true master level to chatlog while under level sync.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "collector",
-    "addon_name": "collector",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "# Collector Finds owned and missing items from a collection of items.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/collector/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "dramagen",
-    "addon_name": "dramagen",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "Dramagen: the only and last parser you will ever need.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "gilbox",
-    "addon_name": "gilbox",
+    "addon_key": "lootscope",
+    "addon_name": "Lootscope",
     "category": "economy_inventory",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "SQLCommit/LootScope"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
+    "best_repo_stars": 2,
     "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "Inventory/economy helper for storage, movement, and selling tasks.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "indinope",
-    "addon_name": "indinope",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "# IndiNope 1.0.4 Hides visual effects from geomancy on players.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/indinope/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "jobinit",
-    "addon_name": "jobinit",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "JobInit: like init.txt, but specific per character per job.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - Loot Drop Tracker",
+    "description_source": "https://github.com/SQLCommit/LootScope",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "kaomoji",
-    "addon_name": "kaomoji",
-    "category": "general_qol",
+    "addon_key": "memscope",
+    "addon_name": "Memscope",
+    "category": "diagnostics",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "SQLCommit/MemScope"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
+    "best_repo_stars": 2,
     "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "kaomoji: minimal kaomoji support for ffxi (behaves like /shrug /tableflip and /unflip do on discord)",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage",
+    "description_source": "https://github.com/SQLCommit/MemScope",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "menufix",
-    "addon_name": "menufix",
-    "category": "general_qol",
+    "addon_key": "zonelines",
+    "addon_name": "Zonelines",
+    "category": "travel_navigation",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "SQLCommit/ZoneLines"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
+    "best_repo_stars": 2,
     "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "create a windowerfolder\\addons\\menufix folder, and put menufix.lua there",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/menufix/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "mousehalo",
-    "addon_name": "mousehalo",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "mousehalo (makes your mouse cursor MUCH more visible. A bit facetious, but working.)",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - Zone Line Visualizer",
+    "description_source": "https://github.com/SQLCommit/ZoneLines",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "ondemand",
-    "addon_name": "ondemand",
-    "category": "general_qol",
+    "addon_key": "debuff-tracker",
+    "addon_name": "Debuff Tracker",
+    "category": "automation",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "ProjectTako/ffxi-addons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "positionmanager",
-    "addon_name": "position_manager",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "**Note**: On some systems with very fast or very slow disks, it can happen that the WinControl addon does not get loaded in time for position_manager to send the proper command.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/position_manager/readme.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "readable",
-    "addon_name": "readable",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "safeoboro",
-    "addon_name": "safeoboro",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "This addon creates a zone of 10' around Oboro where every player that is not you cannot appear. Load it and it's on. Load it before zoning into Port Jeuno for maximum effectiveness. Enjoy some privacy with Oboro! Say goo",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/safeoboro/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "silttracker",
-    "addon_name": "silttracker",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "# silttracker This is a very simple tool I wrote for myself to easily track the earning of beads during intense farming sessions.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/silttracker/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "smeagol",
-    "addon_name": "smeagol",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "Does not use rings inside town. Can toggle with //smeagol town command.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/smeagol/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "special",
-    "addon_name": "special",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "special: makes you feel special.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "tellapart",
-    "addon_name": "tellapart",
-    "category": "chat_qol",
+    "addon_key": "menus",
+    "addon_name": "Menus",
+    "category": "automation",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "ProjectTako/ffxi-addons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "Get support for the addon on FFXIAH: https://www.ffxiah.com/forum/topic/57093/tellapart-add-progressive-letters-to-mob-names/ Names are changed in a way that they are identical across different clients, even if those cli",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/tellapart/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "tellfix",
-    "addon_name": "tellfix",
-    "category": "chat_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "create a windowerfolder\\addons\\tellfix folder, and put tellfix.lua there",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/tellfix/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "tiptoes",
-    "addon_name": "tiptoes",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "tiptoes: applies Sneak and Invisible with a single command according to job: supports spells, Spectral Jig, Ninjutsu, and items (Silent Oils and Prism Powders).",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "tpsreport",
-    "addon_name": "tpsreport",
-    "category": "general_qol",
+    "addon_key": "scanzone",
+    "addon_name": "Scanzone",
+    "category": "travel_navigation",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "ProjectTako/ffxi-addons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "TPSReport: exports an XML list of current alliance members.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "trialtracker",
-    "addon_name": "trialtracker",
-    "category": "general_qol",
+    "addon_key": "turnaround",
+    "addon_name": "Turnaround",
+    "category": "automation",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "ProjectTako/ffxi-addons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autodnc",
+    "addon_name": "Autodnc",
+    "category": "automation",
+    "repos": [
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chococard",
+    "addon_name": "Chococard",
+    "category": "general_qol",
+    "repos": [
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "questlog",
+    "addon_name": "Questlog",
+    "category": "general_qol",
+    "repos": [
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "packetviewerlogviewer",
+    "addon_name": "Packetviewerlogviewer",
+    "category": "diagnostics",
+    "repos": [
+      "ZeromusXYZ/PacketViewerLogViewer"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
+    "description_source": "https://github.com/ZeromusXYZ/PacketViewerLogViewer",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ui",
+    "addon_name": "Ui",
+    "category": "ui_gear",
+    "repos": [
+      "AliekberFFXI/xivcrossbar"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
+    "description_source": "https://github.com/AliekberFFXI/xivcrossbar",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "bursting",
+    "addon_name": "Bursting",
+    "category": "general_qol",
+    "repos": [
+      "ValokAsura/WindowerAddons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 14,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
     "description_confidence": "low"
   },
   {
-    "addon_key": "useall",
-    "addon_name": "useall",
-    "category": "general_qol",
+    "addon_key": "crystaltrader",
+    "addon_name": "Crystaltrader",
+    "category": "economy_inventory",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "ValokAsura/WindowerAddons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
+    "best_repo_stars": 14,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
     "description_confidence": "low"
   },
   {
-    "addon_key": "waveback",
-    "addon_name": "waveback",
-    "category": "general_qol",
+    "addon_key": "quicktrade_2",
+    "addon_name": "Quicktrade 2",
+    "category": "ui_gear",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "ValokAsura/WindowerAddons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "//waveback delay &lt;number&gt; - waits <number> between activations.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/waveback/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "weathermon",
-    "addon_name": "weathermon",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
+    "best_repo_stars": 14,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
     "description_confidence": "low"
   },
   {
-    "addon_key": "witnessprotection",
-    "addon_name": "witnessprotection",
-    "category": "general_qol",
+    "addon_key": "autoassist",
+    "addon_name": "Autoassist",
+    "category": "automation",
     "repos": [
-      "lili-ffxi/FFXI-Addons"
+      "ekrividus/autoAssist"
     ],
     "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 3.84,
-    "description": "# Witness Protection ver. 0.2.0 This addon takes care of renaming all the characters you encounter to random names. The goal is to make it impossible, or at least very difficult, to recognize who you are or what server y",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/witnessprotection/README.md",
-    "description_confidence": "high"
+    "best_repo_stars": 13,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "An ffxi windower addon to automatically assist a party member in combat",
+    "description_source": "https://github.com/ekrividus/autoAssist",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xivhotbar2",
+    "addon_name": "XIvhotbar2",
+    "category": "ui_gear",
+    "repos": [
+      "Technyze/XIVHotbar2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 13,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "assist",
+    "addon_name": "Assist",
+    "category": "automation",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "eradebuffed",
+    "addon_name": "Eradebuffed",
+    "category": "combat_automation",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "eradistanceplus",
+    "addon_name": "Eradistanceplus",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "erainfobar",
+    "addon_name": "Erainfobar",
+    "category": "ui_gear",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "erajobchange",
+    "addon_name": "Erajobchange",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "eramobdrops",
+    "addon_name": "Eramobdrops",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "eramoblevel",
+    "addon_name": "Eramoblevel",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "erapointwatch",
+    "addon_name": "Erapointwatch",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "erascoreboard",
+    "addon_name": "Erascoreboard",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fastfollow",
+    "addon_name": "Fastfollow",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "clickfind",
-    "addon_name": "clickfind",
+    "addon_name": "Clickfind",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -490,9 +1450,9 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 5,
-    "opportunity_score": 3.12,
-    "description": "clickfind (click to print mouse cursor position on screen)",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
@@ -506,15 +1466,15 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 5,
-    "opportunity_score": 3.12,
-    "description": "Dupefind (by Lili, modded by me) : Find and lists duplicate items.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "friendzone",
-    "addon_name": "friendzone",
-    "category": "general_qol",
+    "addon_name": "Friendzone",
+    "category": "travel_navigation",
     "repos": [
       "Icydeath/ffxi-addons",
       "lili-ffxi/FFXI-Addons"
@@ -522,14 +1482,30 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 5,
-    "opportunity_score": 3.12,
-    "description": "Friendzone: automatically calls trusts over and over. A bit bugged but workable.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "omen",
+    "addon_name": "Omen",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mousseng/xitools"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "posfind",
-    "addon_name": "posfind",
+    "addon_name": "Posfind",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -538,14 +1514,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 5,
-    "opportunity_score": 3.12,
-    "description": "posfind (click to print character position on world map)",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons#readme",
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "statsearch",
-    "addon_name": "StatSearch",
+    "addon_name": "Statsearch",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -554,329 +1530,45 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 5,
-    "opportunity_score": 3.12,
-    "description": "# statsearch **NOTE:** due to limitations of the extdata library of windower, statsearch is currently unable to read text from some items, mainly divergence weapons/necks and odyssey gear.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons/blob/HEAD/statsearch/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
-    "addon_key": "debufftracker",
-    "addon_name": "debuff-tracker",
-    "category": "general_qol",
+    "addon_key": "superwarp",
+    "addon_name": "Superwarp",
+    "category": "travel_navigation",
     "repos": [
-      "ProjectTako/ffxi-addons"
+      "AkadenTK/superwarp",
+      "Icydeath/ffxi-addons"
     ],
-    "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.95,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "menus",
-    "addon_name": "menus",
-    "category": "general_qol",
-    "repos": [
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.95,
-    "description": "# ffxi-addons/menus Menus: Menus is an addon for Ashita that allows you to open your delivery box and the auction house anywhere in a zone that normally has those accessible.",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons/blob/HEAD/menus/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "scanzone",
-    "addon_name": "scanzone",
-    "category": "general_qol",
-    "repos": [
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.95,
-    "description": "# ffxi-addons/scanzone ScanZone: Scan Zone is an addon that will let you scan your current zone for any NPC, including mobs.",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons/blob/HEAD/scanzone/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "turnaround",
-    "addon_name": "turnaround",
-    "category": "general_qol",
-    "repos": [
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.95,
-    "description": "# ffxi-addons/turnaround TurnAround: Simple addon used for turning yourself around.",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons/blob/HEAD/turnaround/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "autodnc",
-    "addon_name": "AutoDNC",
-    "category": "combat_automation",
-    "repos": [
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.9,
-    "description": "Automates repeated job or combat actions with rule-based logic.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "chococard",
-    "addon_name": "chococard",
-    "category": "general_qol",
-    "repos": [
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.9,
-    "description": "Chococard === Displays decoded extra data for chocobo items and packets while viewing the padocks inside race track menus.",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/chococard/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "questlog",
-    "addon_name": "QuestLog",
-    "category": "diagnostics",
-    "repos": [
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.9,
-    "description": "# QuestLog used to track progress for adoulin/abyssea quest completion shows abyssea and adoulin quests you have not completed or undertaken ### Commands: ### Color code:",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/QuestLog/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "bursting",
-    "addon_name": "Bursting",
-    "category": "general_qol",
-    "repos": [
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 14,
-    "freshness_max": 2,
-    "opportunity_score": 2.74,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "crystaltrader",
-    "addon_name": "CrystalTrader",
-    "category": "economy_inventory",
-    "repos": [
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 14,
-    "freshness_max": 2,
-    "opportunity_score": 2.74,
-    "description": "Crystal Trader has been replaced with QuickTrade and will no longer be updated.",
-    "description_source": "https://github.com/ValokAsura/WindowerAddons/blob/HEAD/CrystalTrader/readme.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "quicktrade2",
-    "addon_name": "QuickTrade 2",
-    "category": "economy_inventory",
-    "repos": [
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 14,
-    "freshness_max": 2,
-    "opportunity_score": 2.74,
-    "description": "Inventory/economy helper for storage, movement, and selling tasks.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "assist",
-    "addon_name": "assist",
-    "category": "combat_automation",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "Keeps your target synced by assisting a chosen party member.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "eradebuffed",
-    "addon_name": "EraDebuffed",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "eradistanceplus",
-    "addon_name": "EraDistancePlus",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "erainfobar",
-    "addon_name": "EraInfoBar",
-    "category": "ui_gear",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "UI enhancement for combat, targeting, or gear visibility.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "erajobchange",
-    "addon_name": "EraJobChange",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "eramobdrops",
-    "addon_name": "EraMobDrops",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "eramoblevel",
-    "addon_name": "EraMobLevel",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "erapointwatch",
-    "addon_name": "EraPointWatch",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "erascoreboard",
-    "addon_name": "EraScoreboard",
-    "category": "ui_gear",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "UI enhancement for combat, targeting, or gear visibility.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "fastfollow",
-    "addon_name": "FastFollow",
-    "category": "combat_automation",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 2.73,
-    "description": "Combat helper automating timing, actions, or role behavior.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "ambuloot",
-    "addon_name": "ambuloot",
-    "category": "general_qol",
+    "addon_name": "Ambuloot",
+    "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "attackid",
-    "addon_name": "attackid",
+    "addon_name": "Attackid",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -884,14 +1576,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# attackid id\u3092\u6307\u5b9a\u3057\u3066/attack(\u6226\u95d8\u958b\u59cb)\u3092\u3059\u308b\u30a2\u30c9\u30aa\u30f3 - \u4f7f\u3044\u65b9 //atkid 123456 send\u304b\u3089\u4f7f\u7528\u3059\u308b //send @others atkid <tid>",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/attackid/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "attackwithme",
-    "addon_name": "attackwithme",
+    "addon_name": "Attackwithme",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -899,119 +1591,119 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# attackwithme - by yyoshisaur ### :tada: v0.0.7 - modded by icy #### New Settings {...} are optional //awm set master {name} ~ sets current player or name to auto load as master //awm set slave {name} ~ sets current pla",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/attackwithme/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autochain",
-    "addon_name": "AutoChain",
-    "category": "combat_automation",
+    "addon_name": "Autochain",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Automates repeated job or combat actions with rule-based logic.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autopup",
-    "addon_name": "AutoPUP",
-    "category": "combat_automation",
+    "addon_name": "Autopup",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Automates repeated job or combat actions with rule-based logic.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autoraise",
-    "addon_name": "AutoRaise",
-    "category": "combat_automation",
+    "addon_name": "Autoraise",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Automates repeated job or combat actions with rule-based logic.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autoskillchain",
-    "addon_name": "AutoSkillchain",
-    "category": "combat_automation",
+    "addon_name": "Autoskillchain",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Some have been modified by me to suit my own needs, full credit goes to the original creators._ **allseeingeye** by Project Tako **AllWarps** by Ivaar - Gives access to the menu options for the following warps: Homepoint",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "autounm",
-    "addon_name": "AutoUNM",
-    "category": "combat_automation",
+    "addon_name": "Autounm",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Automates repeated job or combat actions with rule-based logic.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autovw",
-    "addon_name": "AutoVW",
-    "category": "combat_automation",
+    "addon_name": "Autovw",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Automates repeated job or combat actions with rule-based logic.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autowatch",
-    "addon_name": "autowatch",
-    "category": "combat_automation",
+    "addon_name": "Autowatch",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "**update 1/17/2021** autowatch (by Langly) : I've had some success with this one.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "blist",
-    "addon_name": "blist",
+    "addon_name": "Blist",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1019,10 +1711,10 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "canteen",
@@ -1034,14 +1726,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# Canteen Load it up then //canteen get when in the #10 portal to get canteen.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/Canteen/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "capetrader",
-    "addon_name": "capetrader",
+    "addon_name": "Capetrader",
     "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1049,14 +1741,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "___ ### Usage notes Load the addon by using the following command: //lua load capetrader There are some conditions that you need to meet in order to use the important go and prep commands: 1.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/capetrader/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "charmed",
-    "addon_name": "charmed",
+    "addon_name": "Charmed",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1064,14 +1756,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "## charmed Created by wes, modified by icy v0.3 : Simple addon to show a pink <3 next to charmed alliance members.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/charmed/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "checkparam",
-    "addon_name": "checkparam",
+    "addon_name": "Checkparam",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1079,14 +1771,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "//checkparam OR //cp (addon command)",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/checkparam/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
-    "addon_key": "crbaddon",
-    "addon_name": "crb_addon",
+    "addon_key": "crb_addon",
+    "addon_name": "Crb Addon",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1094,14 +1786,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
-    "addon_key": "curepleaseaddon",
-    "addon_name": "CurePlease_addon",
+    "addon_key": "cureplease_addon",
+    "addon_name": "Cureplease Addon",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1109,10 +1801,10 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "currencies",
@@ -1124,14 +1816,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Currencies (by Ivaar) : use commands to find the amount of something that is listed your currency/currency2 in-game menus.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "distanceplus",
-    "addon_name": "DistancePlus",
+    "addon_name": "Distanceplus",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1139,10 +1831,10 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Distance Plus adds the following features: * Distance measured to hundredth vs 10th.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/DistancePlus/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "drop",
@@ -1154,14 +1846,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "register chamber, enter chamber, drop lamp ---- If you need further information be sure to check out the addons readme file, otherwise you can skim the addons .lua to get an idea of how it works.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "eschachest",
-    "addon_name": "EschaChest",
+    "addon_name": "Eschachest",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1169,74 +1861,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "EschaChest (by me) : a first attempt at automate opening of chests in escha zones.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "exportitems",
-    "addon_name": "export_items",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "ffxikeys",
-    "addon_name": "ffxikeys",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Original creator: Tny5989 Modified by: Icy # FFXIKeys A small windower addon to automate trading keys for rewards Action | Addon Command --------------------- | ----------------------------- Use | //keys use \\<key\\> Togg",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/ffxikeys/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "finalalert",
-    "addon_name": "finalAlert",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "followme",
-    "addon_name": "followme",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# followme * \u30d5\u30a9\u30ed\u30fc\u958b\u59cb //followme(//fm) start * \u30d5\u30a9\u30ed\u30fc\u89e3\u9664 //followme(//fm) stop * \u30a4\u30aa\u30cb\u30b9\u53d6\u5f97 //followme(//fm) ionis * \u98ef\u76d2(\u30aa\u30fc\u30e1\u30f3)\u53d6\u5f97 //followme(//fm) canteen * \u7948\u7977\u795e\u7b26(\u30c9\u30e1\u30a4\u30f3\u30d9\u30fc\u30b8\u30e7\u30f3)\u53d6\u5f97 -> \u4f1a\u5834\u3078\u30ef\u30fc\u30d7 //followme(//fm) di * \u30de\u30a6\u30f3\u30c8(\u30e9\u30d7\u30c8\u30eb)\u306b\u4e57\u308b //followme",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/followme/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "giltracker",
-    "addon_name": "giltracker",
+    "addon_key": "export_items",
+    "addon_name": "Export Items",
     "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1244,14 +1876,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# giltracker This addon displays the current gil, similar to the FFXIV Gil HUD widget.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/giltracker/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
-    "addon_key": "jobchange",
-    "addon_name": "JobChange",
+    "addon_key": "ffxikeys",
+    "addon_name": "FFXIkeys",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1259,10 +1891,70 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Allows command line job change as long as you're within 6 yalms of a Job Change NPC.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/JobChange/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "finalalert",
+    "addon_name": "Finalalert",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "followme",
+    "addon_name": "Followme",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "giltracker",
+    "addon_name": "Giltracker",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "jobchange",
+    "addon_name": "Jobchange",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "locke",
@@ -1274,14 +1966,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "followme (by yyoshisaur, modded by me) : alt following, get omen canteen, get SR KI, get DI KI Locke (by me) : experimental thf TH Gear swapper.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "lockpick",
-    "addon_name": "lockpick",
+    "addon_name": "Lockpick",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1289,14 +1981,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "maga",
-    "addon_name": "maga",
+    "addon_name": "Maga",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1304,14 +1996,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Edit the buy_list in file **InvSpace** by Kenshi - Shows each inventory containers free space in a moveable box **Juggler** by psykad - Juggler is to simplify the use of Ready commands for jug pets **lazyMB** by kotodama",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "masstrade",
-    "addon_name": "MassTrade",
+    "addon_name": "Masstrade",
     "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1319,29 +2011,29 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# MassTrade MassTrade is a Windower addon that allows users to quickly trade large quantities of the same item to either a PC or NPC.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/MassTrade/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "moveitems",
-    "addon_name": "MoveItems",
-    "category": "general_qol",
+    "addon_name": "Moveitems",
+    "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "myhome",
-    "addon_name": "MyHome",
+    "addon_name": "Myhome",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1349,14 +2041,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# MyHome ## English - Automatically choose and uses a warp spell or an item.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/MyHome/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "myomen",
-    "addon_name": "MyOmen",
+    "addon_name": "Myomen",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1364,29 +2056,29 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "**myomen** - quick way to use your tele ring to get to omen.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "nnitimer",
-    "addon_name": "NniTimer",
-    "category": "general_qol",
+    "addon_name": "Nnitimer",
+    "category": "diagnostics",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "noknock",
-    "addon_name": "noknock",
+    "addon_name": "Noknock",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1394,29 +2086,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "omen",
-    "addon_name": "Omen",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "**myomen** - quick way to use your tele ring to get to omen.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "oneoffs",
-    "addon_name": "OneOffs",
+    "addon_name": "Oneoffs",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1424,29 +2101,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "partypets",
-    "addon_name": "PartyPets",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "petparty",
-    "addon_name": "petparty",
+    "addon_name": "Partypets",
     "category": "ui_gear",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1454,10 +2116,25 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# petparty Displays all pet information for your alliance.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/petparty/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "petparty",
+    "addon_name": "Petparty",
+    "category": "ui_gear",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "positions",
@@ -1469,10 +2146,10 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# Positions Windower Addon for positioning mules The two functions of this addon are to have a character follow someone, and to have a character go to their position for fighting an nm.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/Positions/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "repeater",
@@ -1484,14 +2161,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Commands //repeater Gives current settings for repeater.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/Repeater/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "roe",
-    "addon_name": "roe",
+    "addon_name": "Roe",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1499,14 +2176,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "rolldistance",
-    "addon_name": "rolldistance",
+    "addon_name": "Rolldistance",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1514,14 +2191,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# FFXI Roll Distance Tracks and displays the distance between you and other party members so you know who is in range for your next Phantom Roll.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/rolldistance/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "rtfm",
-    "addon_name": "rtfm",
+    "addon_name": "Rtfm",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1529,29 +2206,29 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "FFXI Windower Addon rtfm - Read The Freakin' Move Detect, alert and list mob moves as they occur in-game.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/rtfm/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "runicportal",
-    "addon_name": "RunicPortal",
-    "category": "travel",
+    "addon_name": "Runicportal",
+    "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "MagicAssistant (by Valok) : updated //maa help for more info RunicPortal (by icy) : Warping via runic portal, get sanction, get assault tag, get assault orders/armband and more.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "schskillchain",
-    "addon_name": "schskillchain",
+    "addon_name": "Schskillchain",
     "category": "combat_automation",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1559,14 +2236,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# schskillchain(ssc) - usage example Open Liquefacrion(\u6eb6\u89e3) //ssc fire open Close Liquefacrion(\u6eb6\u89e3) (settable the first letter of parameter) //ssc f c Close Liquefacrion(\u6eb6\u89e3) and Magic Burst Pyrohelix II (\u706b\u9580\u306e\u8a08II) //ssc f c ",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/schskillchain/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "scriptedextender",
-    "addon_name": "ScriptedExtender",
+    "addon_name": "Scriptedextender",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1574,44 +2251,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "sendalltarget",
-    "addon_name": "SendAllTarget",
-    "category": "ui_gear",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Abbreviation: //sat, //sendalltarget Commands: * //sat alltarget - All boxes on this computer target whatever the sender is targetting.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/SendAllTarget/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "settarget",
-    "addon_name": "SetTarget",
-    "category": "ui_gear",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Shows enhanced target/enemy HP or status display overlays.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "simpleassist",
-    "addon_name": "SimpleAssist",
+    "addon_name": "Sendalltarget",
     "category": "combat_automation",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1619,14 +2266,44 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Keeps your target synced by assisting a chosen party member.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "settarget",
+    "addon_name": "Settarget",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "simpleassist",
+    "addon_name": "Simpleassist",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "sirpopalot",
-    "addon_name": "SirPopaLot",
+    "addon_name": "Sirpopalot",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1634,29 +2311,29 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "smarttarget",
-    "addon_name": "smarttarget",
-    "category": "ui_gear",
+    "addon_name": "Smarttarget",
+    "category": "combat_automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "smarttarget (by anonymous) : helper addon for targeting specific mobs (ie: dynamis D) stars (by chiaia, modded by me) : yell/shout filter, added the ability to filter specific player names targetplus (pastebin) : //tar -",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "spellspammer",
-    "addon_name": "spellSpammer",
+    "addon_name": "Spellspammer",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1664,9 +2341,9 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "**spellSpammer** by Lorand - Set the list of spells that you want to spam in file.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
@@ -1679,25 +2356,10 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# Stars An addon which filters messages based on a filter.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/Stars/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "superwarp",
-    "addon_name": "superwarp",
-    "category": "travel",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "**Feature**: An option has been added to check for unlock status of homepoints, waypoints, and survival guides. To enable unlock checks, set the following setting: <enable_locked_warps>false</enable_locked_warps>. This o",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/superwarp/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "synergy",
@@ -1709,59 +2371,59 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "targeter",
-    "addon_name": "targeter",
-    "category": "ui_gear",
+    "addon_name": "Targeter",
+    "category": "combat_automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# FFXI Targeter *Note: This is a work in progress.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/targeter/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "targetinfoex",
-    "addon_name": "targetinfoEx",
-    "category": "ui_gear",
+    "addon_name": "Targetinfoex",
+    "category": "combat_automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# TargetInfo # This addon shows some memory information of your current target, provided the target is an NPC. This information is otherwise not available in the game. Per settings file adjustable settings: ShowHexID Thi",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/targetinfoEx/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "targetplus",
-    "addon_name": "TargetPlus",
-    "category": "ui_gear",
+    "addon_name": "Targetplus",
+    "category": "combat_automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "smarttarget (by anonymous) : helper addon for targeting specific mobs (ie: dynamis D) stars (by chiaia, modded by me) : yell/shout filter, added the ability to filter specific player names targetplus (pastebin) : //tar -",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "thfknife",
-    "addon_name": "ThfKnife",
+    "addon_name": "Thfknife",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1769,14 +2431,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "tonic",
-    "addon_name": "tonic",
+    "addon_name": "Tonic",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1784,10 +2446,10 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "tonic makes it easier to use Escha temp items",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/tonic/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "trader",
@@ -1799,14 +2461,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Inventory/economy helper for storage, movement, and selling tasks.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "triggers",
-    "addon_name": "triggers",
+    "addon_name": "Triggers",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1814,10 +2476,10 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "tg trigger <string>: Set text trigger.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/triggers/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "valkyrie",
@@ -1829,14 +2491,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# Valkyrie A windower addon to streamline Einherjar entry.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/Valkyrie/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "voidwalker",
-    "addon_name": "voidwalker",
+    "addon_name": "Voidwalker",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1844,14 +2506,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "voidwatch",
-    "addon_name": "voidwatch",
+    "addon_name": "Voidwatch",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1859,14 +2521,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "vwpop",
-    "addon_name": "VWPop",
+    "addon_name": "Vwpop",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1874,29 +2536,29 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "warpmenu",
-    "addon_name": "WarpMenu",
-    "category": "travel",
+    "addon_name": "Warpmenu",
+    "category": "travel_navigation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "~~~~~~~~~~~~~ WarpMenu ~~~~~~~~~~~~~ ==================================== *NOTICE* Requires addon: superwarp ==================================== [warpmenu|wm] [window#|win#] [a|add|r|remove] [hp#] [zone name] > auto tra",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/WarpMenu/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "where",
-    "addon_name": "where",
+    "addon_name": "Where",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1904,14 +2566,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "widescantool",
-    "addon_name": "widescantool",
+    "addon_name": "Widescantool",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1919,29 +2581,29 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Filters: Filters can be useful if widescantool is too cluttered with monsters you do not care about. Fewer entries in the widescan list, and you are less likely to miss something you do care about. Filters can be configu",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/widescantool/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "woehelper",
-    "addon_name": "WoEHelper",
-    "category": "general_qol",
+    "addon_name": "Woehelper",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "xivcrossbar",
-    "addon_name": "xivcrossbar",
+    "addon_name": "XIvcrossbar",
     "category": "ui_gear",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1949,14 +2611,14 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "Update Log 01/25/2021 : Added DRGs pet command macros Steps to get XIVCrossbar working: 1) Install Autohotkey (https://www.autohotkey.com/) 2) Run FFXI Configuration tool and set up your gamepad to match ConfigureYourGam",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/xivcrossbar/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "zenimonsnap",
-    "addon_name": "ZenimonSnap",
+    "addon_name": "Zenimonsnap",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons"
@@ -1964,29 +2626,44 @@
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "ZenimonSnap Automatically equips and uses Soultrapper and Soultrapper 2000 efficiently.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/ZenimonSnap/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "zonename",
-    "addon_name": "zonename",
-    "category": "general_qol",
+    "addon_name": "Zonename",
+    "category": "travel_navigation",
     "repos": [
       "Icydeath/ffxi-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 2.52,
-    "description": "# zonename This addon displays the zone and region name for a short time while changing zones.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/zonename/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "enemybar2",
+    "addon_name": "Enemybar2",
+    "category": "ui_gear",
+    "repos": [
+      "AkadenTK/enemybar2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 19,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
+    "description_source": "https://github.com/AkadenTK/enemybar2",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "ase",
-    "addon_name": "ASE",
+    "addon_name": "Ase",
     "category": "general_qol",
     "repos": [
       "Lygre/addons"
@@ -1994,29 +2671,29 @@
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autoinvite",
-    "addon_name": "autoinvite",
-    "category": "combat_automation",
+    "addon_name": "Autoinvite",
+    "category": "automation",
     "repos": [
       "Lygre/addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "Abbreviation: //ai, //autoinvite Commands: * <whitelist|blacklist> <add|remove> <player> - adds or removes a player from blacklist or whitelist.",
-    "description_source": "https://github.com/Lygre/addons/blob/HEAD/autoinvite/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "broseem",
-    "addon_name": "broseem",
+    "addon_name": "Broseem",
     "category": "general_qol",
     "repos": [
       "Lygre/addons"
@@ -2024,14 +2701,14 @@
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "impalert",
-    "addon_name": "ImpAlert",
+    "addon_name": "Impalert",
     "category": "general_qol",
     "repos": [
       "Lygre/addons"
@@ -2039,29 +2716,14 @@
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
-    "addon_key": "parse",
-    "addon_name": "parse",
-    "category": "diagnostics",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "Parses combat logs for damage/performance summaries.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "petfix",
-    "addon_name": "pet_fix",
+    "addon_key": "pet_fix",
+    "addon_name": "Pet Fix",
     "category": "general_qol",
     "repos": [
       "Lygre/addons"
@@ -2069,14 +2731,14 @@
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
-    "addon_key": "pluginmanager",
-    "addon_name": "plugin_manager",
+    "addon_key": "plugin_manager",
+    "addon_name": "Plugin Manager",
     "category": "general_qol",
     "repos": [
       "Lygre/addons"
@@ -2084,29 +2746,29 @@
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "2 Click the icon next to \"plugin_manager\"",
-    "description_source": "https://github.com/Lygre/addons/blob/HEAD/plugin_manager/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "rollbot",
-    "addon_name": "RollBot",
-    "category": "general_qol",
+    "addon_name": "Rollbot",
+    "category": "automation",
     "repos": [
       "Lygre/addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "skilluptracker",
-    "addon_name": "skilluptracker",
+    "addon_name": "Skilluptracker",
     "category": "general_qol",
     "repos": [
       "Lygre/addons"
@@ -2114,14 +2776,14 @@
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "skilluptracker [show|hide] [all|craft|magic|combat]:",
-    "description_source": "https://github.com/Lygre/addons/blob/HEAD/skilluptracker/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "stna",
-    "addon_name": "stna",
+    "addon_name": "Stna",
     "category": "general_qol",
     "repos": [
       "Lygre/addons"
@@ -2129,14 +2791,14 @@
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "stopwatch",
-    "addon_name": "stopwatch",
+    "addon_name": "Stopwatch",
     "category": "general_qol",
     "repos": [
       "Lygre/addons"
@@ -2144,10 +2806,10 @@
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "**Commands:** sw start to start the stopwatch sw stop to pause the stopwatch sw reset to reset the stopwatch cumulative time to 0 Addon by Patrick Finnigan (Puhfyn@Ragnarok) - https://github.com/finnigantime.",
-    "description_source": "https://github.com/Lygre/addons/blob/HEAD/stopwatch/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "text",
@@ -2159,74 +2821,44 @@
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "translate",
-    "addon_name": "translate",
-    "category": "chat_qol",
+    "addon_name": "Translate",
+    "category": "general_qol",
     "repos": [
       "Lygre/addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 2.4,
-    "description": "Chat/communication quality-of-life utility.",
-    "description_source": "heuristic",
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xivhotbar",
+    "addon_name": "XIvhotbar",
+    "category": "ui_gear",
+    "repos": [
+      "Akirane/XIVHotbar"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "",
+    "description_source": "",
     "description_confidence": "low"
   },
   {
     "addon_key": "barfiller",
-    "addon_name": "barfiller",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "chars",
-    "addon_name": "chars",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "**fix:** pattern wasn't working with some special chars.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/chars/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "chatlink",
-    "addon_name": "ChatLink",
-    "category": "chat_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "Chat/communication quality-of-life utility.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "enemybar",
-    "addon_name": "enemybar",
+    "addon_name": "Barfiller",
     "category": "ui_gear",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2234,14 +2866,59 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "# enemybar This is an addon for Windower4 for FFXI.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/enemybar/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chars",
+    "addon_name": "Chars",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatlink",
+    "addon_name": "Chatlink",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "enemybar",
+    "addon_name": "Enemybar",
+    "category": "ui_gear",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "ffxicaddieprovider",
-    "addon_name": "ffxicaddieProvider",
+    "addon_name": "FFXIcaddieprovider",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2249,14 +2926,14 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "highlight",
-    "addon_name": "highlight",
+    "addon_name": "Highlight",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2264,14 +2941,14 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "##Description This addon highlights the names of the people in your party, and highlights their name when it appears in chat.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/highlight/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "inforeplacer",
-    "addon_name": "InfoReplacer",
+    "addon_name": "Inforeplacer",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2279,10 +2956,10 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "lazy",
@@ -2294,10 +2971,10 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "nostrum",
@@ -2309,14 +2986,14 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "ohshi",
-    "addon_name": "ohShi",
+    "addon_name": "Ohshi",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2324,14 +3001,14 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "**Abbreviation:** //ohShi **Commands:** 1.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/ohShi/Readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "plasmon",
-    "addon_name": "plasmon",
+    "addon_name": "Plasmon",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2339,14 +3016,14 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "**-o _objects_:** specifies the item/s which will have its/their color changed. If this parameter is missing all the objects will be changed. The accepted values are: **all**, **background**, **bg**, **title**, **label**",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/plasmon/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "reive",
-    "addon_name": "reive",
+    "addon_name": "Reive",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2354,10 +3031,10 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "**-o _objects_:** specifies the item/s which will have its/their color changed. If this parameter is missing all the objects will be changed. the accepted values are **all**, **background**, **bg**, **title**, **label**,",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/reive/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "rhombus",
@@ -2369,14 +3046,14 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "salvage2",
-    "addon_name": "salvage2",
+    "addon_name": "Salvage2",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2384,14 +3061,14 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "Author: Krizz Version: .5 Date: 20130601 Salvage2 Abbreviation: //s2 Commands: * help - Shows a menu of commands in game * pos <x> <y> - Positions the pathos remaining box.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/salvage2/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "satacast",
-    "addon_name": "SATACast",
+    "addon_name": "Satacast",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2399,14 +3076,14 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "setbgm",
-    "addon_name": "setbgm",
+    "addon_name": "Setbgm",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2414,29 +3091,29 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "strathelper",
-    "addon_name": "StratHelper",
-    "category": "general_qol",
+    "addon_name": "Strathelper",
+    "category": "automation",
     "repos": [
       "mverteuil/windower4-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "StratHelper ===== StratHelper is a simple helper addon for Spellcast for Scholar Stratagems.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/StratHelper/Readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "taps",
-    "addon_name": "taps",
+    "addon_name": "Taps",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2444,29 +3121,29 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "targetinfo",
-    "addon_name": "targetinfo",
-    "category": "ui_gear",
+    "addon_name": "Targetinfo",
+    "category": "combat_automation",
     "repos": [
       "mverteuil/windower4-addons"
     ],
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "# TargetInfo # This addon shows some memory information of your current target, provided the target is an NPC.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/targetinfo/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "truesight",
-    "addon_name": "truesight",
+    "addon_name": "Truesight",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2474,14 +3151,14 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "visiblefavor",
-    "addon_name": "VisibleFavor",
+    "addon_name": "Visiblefavor",
     "category": "general_qol",
     "repos": [
       "mverteuil/windower4-addons"
@@ -2489,10 +3166,10 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "yush",
@@ -2504,14 +3181,31 @@
     "repo_count": 1,
     "best_repo_stars": 17,
     "freshness_max": 1,
-    "opportunity_score": 2.39,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "skillchain",
+    "addon_name": "Skillchain",
+    "category": "combat_automation",
+    "repos": [
+      "Lygre/addons",
+      "mousseng/xitools",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 3,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 3.26,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "allseeingeye",
-    "addon_name": "allseeingeye",
+    "addon_name": "Allseeingeye",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2520,15 +3214,15 @@
     "repo_count": 2,
     "best_repo_stars": 99,
     "freshness_max": 2,
-    "opportunity_score": 2.15,
-    "description": "# ffxi-addons/allseeingeye AllSeeingEyes: This was popularized long ago from the Windower 3.x plugin with the same name.",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons/blob/HEAD/allseeingeye/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "equipviewer",
-    "addon_name": "equipviewer",
-    "category": "ui_gear",
+    "addon_name": "Equipviewer",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "ProjectTako/ffxi-addons"
@@ -2536,15 +3230,15 @@
     "repo_count": 2,
     "best_repo_stars": 99,
     "freshness_max": 2,
-    "opportunity_score": 2.15,
-    "description": "# ffxi-addons/equipviewer EquipViewer: Overlays your currently equipped items onto the screen anywhere.",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons/blob/HEAD/equipviewer/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "partybuffs",
-    "addon_name": "partybuffs",
-    "category": "ui_gear",
+    "addon_name": "Partybuffs",
+    "category": "automation",
     "repos": [
       "Lygre/addons",
       "ProjectTako/ffxi-addons"
@@ -2552,15 +3246,15 @@
     "repo_count": 2,
     "best_repo_stars": 99,
     "freshness_max": 2,
-    "opportunity_score": 2.15,
-    "description": "# ffxi-addons/partybuffs An addon made from https://github.com/KenshiDRK/Addons/tree/master/PartyBuffs for Ashita.",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons/blob/HEAD/partybuffs/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "react",
-    "addon_name": "react",
-    "category": "combat_automation",
+    "addon_name": "React",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "ProjectTako/ffxi-addons"
@@ -2568,15 +3262,15 @@
     "repo_count": 2,
     "best_repo_stars": 99,
     "freshness_max": 2,
-    "opportunity_score": 2.15,
-    "description": "# ffxi-addons/react React: Based on the Windower addon by Sammeh (https://github.com/SammehFFXI/FFXIAddons/tree/master/React), works very similar.",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons/blob/HEAD/react/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autocor",
-    "addon_name": "AutoCOR",
-    "category": "combat_automation",
+    "addon_name": "Autocor",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "Ivaar/Windower-addons"
@@ -2584,15 +3278,15 @@
     "repo_count": 2,
     "best_repo_stars": 79,
     "freshness_max": 2,
-    "opportunity_score": 2.1,
-    "description": "Accepts auto-translate terms, not case-sensitive. \"//cor [on|off]\" \"//cor roll <n> <job|roll_name>\" -- set roll \"//cor cc [n|off]\" -- Use crooked cards on roll [n] (default is 1st roll, 0 is off) \"//cor aoe <slot|party> ",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/AutoCOR/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autogeo",
-    "addon_name": "AutoGEO",
-    "category": "combat_automation",
+    "addon_name": "Autogeo",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "Ivaar/Windower-addons"
@@ -2600,30 +3294,14 @@
     "repo_count": 2,
     "best_repo_stars": 79,
     "freshness_max": 2,
-    "opportunity_score": 2.1,
-    "description": "Some have been modified by me to suit my own needs, full credit goes to the original creators._ **allseeingeye** by Project Tako **AllWarps** by Ivaar - Gives access to the menu options for the following warps: Homepoint",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "chatman",
-    "addon_name": "ChatMan",
-    "category": "chat_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.1,
-    "description": "ChatManager ============= Alternative to chatmon.",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/ChatMan/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "htmb",
-    "addon_name": "htmb",
+    "addon_name": "Chatman",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2632,14 +3310,30 @@
     "repo_count": 2,
     "best_repo_stars": 79,
     "freshness_max": 2,
-    "opportunity_score": 2.1,
-    "description": "//htmb - When near one of the KI NPCs, it will buy the KI\\'s you have set.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/htmb/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "htmb",
+    "addon_name": "Htmb",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "porterpacker",
-    "addon_name": "PorterPacker",
+    "addon_name": "Porterpacker",
     "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2648,15 +3342,15 @@
     "repo_count": 2,
     "best_repo_stars": 79,
     "freshness_max": 2,
-    "opportunity_score": 2.1,
-    "description": "# PorterPacker ### Commands: command|alias [optional] //porterpacker or //packer or //po",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/PorterPacker/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "singer",
     "addon_name": "Singer",
-    "category": "combat_automation",
+    "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
       "Ivaar/Windower-addons"
@@ -2664,14 +3358,14 @@
     "repo_count": 2,
     "best_repo_stars": 79,
     "freshness_max": 2,
-    "opportunity_score": 2.1,
-    "description": "# Sing ### Automates casting of bard buff songs. #### If you are updating from a version prior to 1.20.05.09 make sure you delete your existing settings.xml file located within the addons data folder. Configure songs wit",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/Singer/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "tradenpc",
-    "addon_name": "TradeNPC",
+    "addon_name": "Tradenpc",
     "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2680,15 +3374,15 @@
     "repo_count": 2,
     "best_repo_stars": 79,
     "freshness_max": 2,
-    "opportunity_score": 2.1,
-    "description": "# TradeNPC Trade an npc up to 8 stacks of items and gil with a single command.",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/TradeNPC/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "magicassistant",
-    "addon_name": "MagicAssistant",
-    "category": "combat_automation",
+    "addon_name": "Magicassistant",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "ValokAsura/WindowerAddons"
@@ -2696,15 +3390,15 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 2,
-    "opportunity_score": 2.07,
-    "description": "**SurvivalGuide** by SammehFFXI - //sg warp <zone> , soft-locks use //terminate **unm** by Darkdoom **MagicAssistant** by [Valok] -Automated magic bursting script //maa nap [spell/helix/ga/ja/ra/nin] [tier] **tonic** - u",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "quicktrade",
-    "addon_name": "QuickTrade",
-    "category": "economy_inventory",
+    "addon_name": "Quicktrade",
+    "category": "ui_gear",
     "repos": [
       "Icydeath/ffxi-addons",
       "ValokAsura/WindowerAddons"
@@ -2712,15 +3406,15 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 2,
-    "opportunity_score": 2.07,
-    "description": "Geas Fete: Key Item detection added. QuickTrade will not try to trade for a Key Item you already posses.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/QuickTrade/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "sendtarget",
-    "addon_name": "SendTarget",
-    "category": "ui_gear",
+    "addon_name": "Sendtarget",
+    "category": "combat_automation",
     "repos": [
       "DiscipleOfEris/Windower4Addons",
       "Icydeath/ffxi-addons"
@@ -2728,14 +3422,30 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 2,
-    "opportunity_score": 2.07,
-    "description": "# SendTarget FFXI Windower addon that allows multiboxers to more easily send commands.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/SendTarget/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "parse",
+    "addon_name": "Parse",
+    "category": "diagnostics",
+    "repos": [
+      "Lygre/addons",
+      "flippant/parse"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "anchor",
-    "addon_name": "anchor",
+    "addon_name": "Anchor",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2744,15 +3454,15 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "Some have been modified by me to suit my own needs, full credit goes to the original creators._ **allseeingeye** by Project Tako **AllWarps** by Ivaar - Gives access to the menu options for the following warps: Homepoint",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "autocontrol",
-    "addon_name": "autocontrol",
-    "category": "combat_automation",
+    "addon_name": "Autocontrol",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "Lygre/addons"
@@ -2760,15 +3470,15 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "**Abbreviations:** acon, autocontrol **Commands:** 1.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/autocontrol/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autojoin",
-    "addon_name": "autojoin",
-    "category": "combat_automation",
+    "addon_name": "Autojoin",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "Lygre/addons"
@@ -2776,15 +3486,15 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "# AutoJoin Once loaded, will automatically join party and alliance invites.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/autojoin/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autows",
-    "addon_name": "AutoWS",
-    "category": "combat_automation",
+    "addon_name": "Autows",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "Lygre/addons"
@@ -2792,14 +3502,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "Automates repeated job or combat actions with rule-based logic.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "azuresets",
-    "addon_name": "azureSets",
+    "addon_name": "Azuresets",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2808,10 +3518,10 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "**Author:** Ricky Gall **Version:** 1.24 **Description:** Addon to make setting blue spells easier. Currently only works as blu main. **Abbreviations:** aset, azureset **Commands:** 1. //aset removeall - Unsets all spell",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/azureSets/Readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "clock",
@@ -2824,14 +3534,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "dostuff",
-    "addon_name": "dostuff",
+    "addon_name": "Dostuff",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2840,15 +3550,15 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "'dos delay': Specify delay (default is 5 secs). This can be adjusted while dostuff is running if needed.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/dostuff/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "dynamishelper",
-    "addon_name": "dynamishelper",
-    "category": "general_qol",
+    "addon_name": "Dynamishelper",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "mverteuil/windower4-addons"
@@ -2856,14 +3566,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "Authors: Krizz Version: 1 Date: 20130419 Dynamis Helper Abbreviation: //dh Commands: * help - Shows a menu of commands in game * timer [on/off] - Displays a timer each time a mob is staggered.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/dynamishelper/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "fisher",
-    "addon_name": "fisher",
+    "addon_name": "Fisher",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2872,14 +3582,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "Fisher will always confuse 1 gil and 100 gil.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/fisher/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "lottery",
-    "addon_name": "lottery",
+    "addon_name": "Lottery",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2888,14 +3598,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "macrochanger",
-    "addon_name": "macrochanger",
+    "addon_name": "Macrochanger",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2904,14 +3614,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "porter",
-    "addon_name": "porter",
+    "addon_name": "Porter",
     "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2920,14 +3630,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "**add**: New command, porter find.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/porter/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "send",
-    "addon_name": "send",
+    "addon_name": "Send",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2936,10 +3646,10 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "## Usage The target can be the receiver's name, @all to send to all instances, @other to send to all instances excluding the sender or @<job> to send to a specific job.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/send/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "silence",
@@ -2952,15 +3662,15 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "Use the line \"silence mode 0\" to not allow any lines to go through.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/Silence/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "subtarget",
-    "addon_name": "SubTarget",
-    "category": "ui_gear",
+    "addon_name": "Subtarget",
+    "category": "combat_automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "Lygre/addons"
@@ -2968,14 +3678,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "name = 'SubTarget' version = '1.0' author = 'Sebyg666' Must have the \"send\" addon to work can use //subtarget or //sta Command \"HELP\" or no command: Explanation of the addons usage printed to the console, essentially the",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/SubTarget/README.txt",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "thtracker",
-    "addon_name": "thtracker",
+    "addon_name": "Thtracker",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -2984,30 +3694,14 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "Authors: Krizz Version: 1.0 Date: 20170509 TH Tracker Abbreviation: //th Commands: * help - Shows a menu of commands in game * pos x y - Positions the TH box.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/thtracker/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "timestamp",
-    "addon_name": "timestamp",
-    "category": "chat_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "**_format_:** defines the timestamp's format. The available constants are: **${year}**, **${y}**, **${year_short}**, **${month}**, **${m}**, **${month_short}**, **${month_long}**, **${day}**, **${d}**, **${day_short}**, ",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/timestamp/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "treasurepool",
-    "addon_name": "TreasurePool",
+    "addon_name": "Timestamp",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3016,14 +3710,78 @@
     "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.72,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "treasurepool",
+    "addon_name": "Treasurepool",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autosynth",
-    "addon_name": "autoSynth",
+    "addon_name": "Autosynth",
+    "category": "automation",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "bluguide",
+    "addon_name": "Bluguide",
+    "category": "travel_navigation",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "boxdestroyer",
+    "addon_name": "Boxdestroyer",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "debuffed",
+    "addon_name": "Debuffed",
     "category": "combat_automation",
     "repos": [
       "Lygre/addons",
@@ -3032,62 +3790,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "Automates repeated job or combat actions with rule-based logic.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "bluguide",
-    "addon_name": "bluguide",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "boxdestroyer",
-    "addon_name": "boxdestroyer",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "debuffed",
-    "addon_name": "Debuffed",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "digger",
-    "addon_name": "digger",
+    "addon_name": "Digger",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3096,14 +3806,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "distance",
-    "addon_name": "distance",
+    "addon_name": "Distance",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3112,14 +3822,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "# Distance Emulates the functionality of the Distance plugin.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/distance/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "gametime",
-    "addon_name": "gametime",
+    "addon_name": "Gametime",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3128,14 +3838,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "instals",
-    "addon_name": "instaLS",
+    "addon_name": "Instals",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3144,14 +3854,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "latentchecker",
-    "addon_name": "latentchecker",
+    "addon_name": "Latentchecker",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3160,14 +3870,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "linker",
-    "addon_name": "linker",
+    "addon_name": "Linker",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3176,14 +3886,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "# Linker Opens certain links via simple console commands, with an optional search string.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/linker/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "ohnoyoudont",
-    "addon_name": "OhNoYouDont",
+    "addon_name": "Ohnoyoudont",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3192,14 +3902,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "opensesame",
-    "addon_name": "OpenSesame",
+    "addon_name": "Opensesame",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3208,14 +3918,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "packetviewer",
-    "addon_name": "PacketViewer",
+    "addon_name": "Packetviewer",
     "category": "diagnostics",
     "repos": [
       "Lygre/addons",
@@ -3224,14 +3934,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "Diagnostic utility for logs, packets, or runtime behavior visibility.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "pettp",
-    "addon_name": "PetTP",
+    "addon_name": "Pettp",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3240,10 +3950,10 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "pricer",
@@ -3256,14 +3966,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "rolltracker",
-    "addon_name": "rolltracker",
+    "addon_name": "Rolltracker",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3272,15 +3982,15 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "If you have rolled a lucky roll, it will also prompt you and automatically stop you from doubling up on it (which can be bypassed by either doubling up again, or typing //rolltracker autostop Enjoy.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/rolltracker/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "scoreboard",
-    "addon_name": "scoreboard",
-    "category": "ui_gear",
+    "addon_name": "Scoreboard",
+    "category": "general_qol",
     "repos": [
       "Lygre/addons",
       "mverteuil/windower4-addons"
@@ -3288,30 +3998,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "UI enhancement for combat, targeting, or gear visibility.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "skillchain",
-    "addon_name": "Skillchain",
-    "category": "combat_automation",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "Displays skillchain options/windows and timing during combat.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "speedchecker",
-    "addon_name": "SpeedChecker",
+    "addon_name": "Speedchecker",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3320,14 +4014,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "spellcheck",
-    "addon_name": "SpellCheck",
+    "addon_name": "Spellcheck",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3336,15 +4030,15 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "#SpellCheck This addon lists spells you haven't unlocked yet.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/SpellCheck/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "sprint",
     "addon_name": "Sprint",
-    "category": "travel",
+    "category": "general_qol",
     "repos": [
       "Lygre/addons",
       "mverteuil/windower4-addons"
@@ -3352,14 +4046,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "Travel quality-of-life helper for warps and navigation.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "synthall",
-    "addon_name": "synthall",
+    "addon_name": "Synthall",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3368,14 +4062,14 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "update",
-    "addon_name": "update",
+    "addon_name": "Update",
     "category": "general_qol",
     "repos": [
       "Lygre/addons",
@@ -3384,33 +4078,33 @@
     "repo_count": 2,
     "best_repo_stars": 18,
     "freshness_max": 1,
-    "opportunity_score": 1.6,
-    "description": "# Update Once loaded can update all addons and plugins to the newest version using //update.",
-    "description_source": "https://github.com/mverteuil/windower4-addons/blob/HEAD/update/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
   },
   {
-    "addon_key": "fastcs",
-    "addon_name": "fastcs",
-    "category": "general_qol",
+    "addon_key": "skillchains",
+    "addon_name": "Skillchains",
+    "category": "combat_automation",
     "repos": [
       "Icydeath/ffxi-addons",
+      "Ivaar/Skillchains",
       "Lygre/addons",
-      "ProjectTako/ffxi-addons",
       "mverteuil/windower4-addons"
     ],
     "repo_count": 4,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 1.35,
-    "description": "# ffxi-addons/fastcs FastCS: FastCS is an addon based on the Windower4 addon with the same name.",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons/blob/HEAD/fastcs/README.md",
-    "description_confidence": "high"
+    "best_repo_stars": 69,
+    "freshness_max": 3,
+    "opportunity_score": 2.27,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "low"
   },
   {
     "addon_key": "auctionhelper",
-    "addon_name": "AuctionHelper",
-    "category": "economy_inventory",
+    "addon_name": "Auctionhelper",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "Ivaar/Windower-addons",
@@ -3419,28 +4113,10 @@
     "repo_count": 3,
     "best_repo_stars": 79,
     "freshness_max": 2,
-    "opportunity_score": 1.3,
-    "description": "AuctionHelper ============= Auction house bidding tool - addon for Windower ----------------------------------------------- Allows you to perform auction house actions with commands, much like bidder with additional func",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/AuctionHelper/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "sellnpc",
-    "addon_name": "SellNPC",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons",
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 4,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 1.3,
-    "description": "# SellNPC ### Command Usage: Sales are now triggered by opening a shop window, you will need to queue items prior to this.",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/SellNPC/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.21,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "trade",
@@ -3454,14 +4130,50 @@
     "repo_count": 3,
     "best_repo_stars": 79,
     "freshness_max": 2,
-    "opportunity_score": 1.3,
-    "description": "# Trade #### Accepts trade requests and confirms from whitelisted players.",
-    "description_source": "https://github.com/Ivaar/Windower-addons/blob/HEAD/Trade/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 2.21,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fastcs",
+    "addon_name": "Fastcs",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons",
+      "ProjectTako/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 4,
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 1.92,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "sellnpc",
+    "addon_name": "Sellnpc",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons",
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 4,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 1.92,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "low"
   },
   {
     "addon_key": "aecho",
-    "addon_name": "aecho",
+    "addon_name": "Aecho",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3471,15 +4183,15 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "autora",
-    "addon_name": "AutoRA",
-    "category": "combat_automation",
+    "addon_name": "Autora",
+    "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
       "Lygre/addons",
@@ -3488,14 +4200,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "2.0.0 AutoRA simply causes ranged attacks to behave like the melee Auto-Attack while your weapon is drawn.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/AutoRA/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "battlemod",
-    "addon_name": "battlemod",
+    "addon_name": "Battlemod",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3505,14 +4217,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "unload - unloads Battlemod",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/battlemod/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "cancel",
-    "addon_name": "cancel",
+    "addon_name": "Cancel",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3522,14 +4234,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "consolebg",
-    "addon_name": "ConsoleBG",
+    "addon_name": "Consolebg",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3539,15 +4251,15 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "dressup",
-    "addon_name": "DressUp",
-    "category": "ui_gear",
+    "addon_name": "Dressup",
+    "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
       "Lygre/addons",
@@ -3556,14 +4268,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "Applies visual appearance/style overrides.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "enternity",
-    "addon_name": "enternity",
+    "addon_name": "Enternity",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3573,31 +4285,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "**Author:** Giuliano Riccio **Version:** v 1.20131102 # Enternity # Enters \"Enter\" automatically when prompted during a cutscene or when talking to NPCs.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/enternity/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "eval",
-    "addon_name": "eval",
-    "category": "diagnostics",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 3,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "Author: Aureus Version: 1.0 Addon to evaluate lua code via windower commands Abbreviation: //eval Use //eval to run arbitrary lua code.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/eval/readme.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "findall",
-    "addon_name": "findAll",
+    "addon_name": "Eval",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3607,14 +4302,31 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "# FindAll This addon searches items stored on all your characters.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/findAll/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "findall",
+    "addon_name": "Findall",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 3,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "gearswap",
-    "addon_name": "GearSwap",
+    "addon_name": "Gearswap",
     "category": "ui_gear",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3624,31 +4336,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "PLEASE DO NOT MESSAGE ME ABOUT ANYTHING THIRD PARTY IN GAME, however feel free to send me a way to contact you outside of game, through the game, and I'm happy to help, my preferred way of being contact is Discord, my St",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/GearSwap/README.md",
-    "description_confidence": "high"
-  },
-  {
-    "addon_key": "healbot",
-    "addon_name": "HealBot",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 3,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "To load healBot: //lua load healbot",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/HealBot/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "invspace",
-    "addon_name": "InvSpace",
+    "addon_name": "Invspace",
     "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3658,15 +4353,15 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "Edit the buy_list in file **InvSpace** by Kenshi - Shows each inventory containers free space in a moveable box **Juggler** by psykad - Juggler is to simplify the use of Ready commands for jug pets **lazyMB** by kotodama",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "itemizer",
-    "addon_name": "itemizer",
-    "category": "general_qol",
+    "addon_name": "Itemizer",
+    "category": "economy_inventory",
     "repos": [
       "Icydeath/ffxi-addons",
       "Lygre/addons",
@@ -3675,10 +4370,10 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "#Itemizer Provides a chat/console interface for moving items around between bags.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/itemizer/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "logger",
@@ -3692,14 +4387,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "Diagnostic utility for logs, packets, or runtime behavior visibility.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "organizer",
-    "addon_name": "organizer",
+    "addon_name": "Organizer",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3709,14 +4404,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "pointwatch",
-    "addon_name": "pointwatch",
+    "addon_name": "Pointwatch",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3726,31 +4421,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "General FFXI quality-of-life utility addon.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "pouches",
     "addon_name": "Pouches",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 3,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "Inventory/economy helper for storage, movement, and selling tasks.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "shortcuts",
-    "addon_name": "shortcuts",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3760,15 +4438,15 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "#Shortcuts v2.9 ####written by Byrth Completes and properly formats commands (prefixed by at least one '/'), including emotes and checks.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/shortcuts/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
-    "addon_key": "skillchains",
-    "addon_name": "Skillchains",
-    "category": "combat_automation",
+    "addon_key": "shortcuts",
+    "addon_name": "Shortcuts",
+    "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
       "Lygre/addons",
@@ -3777,10 +4455,10 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "# SkillChains ### Active Battle Skillchain Display.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/Skillchains/README.md",
-    "description_confidence": "high"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "sparks",
@@ -3794,14 +4472,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "**unm** - Updated to Darkdoom's v2, further modified the script to include the force option; which allows the player to continue to pop the unm even if sparks are capped.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons#readme",
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
     "addon_key": "tparty",
-    "addon_name": "TParty",
+    "addon_name": "Tparty",
     "category": "ui_gear",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3811,31 +4489,14 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "UI enhancement for combat, targeting, or gear visibility.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "treasury",
     "addon_name": "Treasury",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 3,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "Automates treasure pool lot/pass/drop decisions.",
-    "description_source": "heuristic",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "zonetimer",
-    "addon_name": "zonetimer",
     "category": "general_qol",
     "repos": [
       "Icydeath/ffxi-addons",
@@ -3845,9 +4506,44 @@
     "repo_count": 3,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 0.92,
-    "description": "Commands: zonetimer posX # change the x position zonetimer posY # change the y position zonetimer fontsize # change the fontsize zoentimer help print these instructions in the log Original plugin by Krellion.",
-    "description_source": "https://github.com/Icydeath/ffxi-addons/blob/HEAD/zonetimer/readme.md",
-    "description_confidence": "high"
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "zonetimer",
+    "addon_name": "Zonetimer",
+    "category": "travel_navigation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 3,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 1.86,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "healbot",
+    "addon_name": "Healbot",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons",
+      "lorand-ffxi/HealBot",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 4,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 1.57,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "low"
   }
 ]

--- a/ffxi_addons_index_raw.json
+++ b/ffxi_addons_index_raw.json
@@ -213,10 +213,20 @@
   {
     "repo": "cyritegamestudios/trust",
     "stars": 49,
-    "pushed_at": "2026-04-23T03:18:39Z",
+    "pushed_at": "2026-04-23T04:17:39Z",
     "description": "Windower 4 addon for FFXI to automate your character in battle.",
     "addon_dirs": [
       "trust"
+    ]
+  },
+  {
+    "repo": "Tylas11/XivParty",
+    "stars": 47,
+    "pushed_at": "2026-02-26T20:01:30Z",
+    "description": "A party list addon for Windower 4.",
+    "addon_dirs": [
+      "assets",
+      "layouts"
     ]
   },
   {
@@ -261,12 +271,64 @@
     ]
   },
   {
+    "repo": "mousseng/xitools",
+    "stars": 29,
+    "pushed_at": "2026-03-10T17:38:26Z",
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "addon_dirs": [
+      "bluspells",
+      "chatty",
+      "colure",
+      "dxui",
+      "imrecast",
+      "libs",
+      "loggers",
+      "minimap-helper",
+      "omen",
+      "rcheck",
+      "relicge",
+      "repl",
+      "skillchain",
+      "strats",
+      "trials",
+      "wheel",
+      "xitools"
+    ]
+  },
+  {
     "repo": "lorand-ffxi/HealBot",
     "stars": 28,
     "pushed_at": "2018-05-22T20:21:49Z",
     "description": "No updates planned in the near future - been too busy with work and life.",
     "addon_dirs": [
       "data"
+    ]
+  },
+  {
+    "repo": "iLVL-Key/FFXI",
+    "stars": 22,
+    "pushed_at": "2026-04-22T15:03:22Z",
+    "description": "Various FFXI projects",
+    "addon_dirs": [
+      "Attend",
+      "Bars",
+      "BattlePlan",
+      "Callouts",
+      "Exorcist",
+      "GaolPlan",
+      "Helper",
+      "Informer",
+      "Jingle",
+      "LLMChat",
+      "Leaderboard",
+      "ReadyCheck",
+      "Sweeper",
+      "TaskBar",
+      "VanaFacts",
+      "VanaPad",
+      "Vanity",
+      "ZNMTracker",
+      "emotes"
     ]
   },
   {
@@ -375,20 +437,6 @@
     ]
   },
   {
-    "repo": "ZeromusXYZ/PacketViewerLogViewer",
-    "stars": 17,
-    "pushed_at": "2023-05-18T06:00:22Z",
-    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
-    "addon_dirs": [
-      "Properties",
-      "Res",
-      "data",
-      "forms",
-      "helpers",
-      "redist"
-    ]
-  },
-  {
     "repo": "AliekberFFXI/xivcrossbar",
     "stars": 17,
     "pushed_at": "2022-09-15T22:03:23Z",
@@ -485,12 +533,17 @@
     ]
   },
   {
-    "repo": "HealsCodes/statustimers",
-    "stars": 15,
-    "pushed_at": "2026-03-01T14:25:55Z",
-    "description": "Statustimers for Ashita v4",
+    "repo": "ZeromusXYZ/PacketViewerLogViewer",
+    "stars": 17,
+    "pushed_at": "2023-05-18T06:00:22Z",
+    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
     "addon_dirs": [
-      "addons"
+      "Properties",
+      "Res",
+      "data",
+      "forms",
+      "helpers",
+      "redist"
     ]
   },
   {
@@ -499,6 +552,15 @@
     "pushed_at": "2023-08-12T01:51:20Z",
     "description": "FFXI Parser Addon for Windower",
     "addon_dirs": []
+  },
+  {
+    "repo": "HealsCodes/statustimers",
+    "stars": 15,
+    "pushed_at": "2026-03-01T14:25:55Z",
+    "description": "Statustimers for Ashita v4",
+    "addon_dirs": [
+      "addons"
+    ]
   },
   {
     "repo": "ValokAsura/WindowerAddons",
@@ -514,6 +576,13 @@
     ]
   },
   {
+    "repo": "ekrividus/autoAssist",
+    "stars": 13,
+    "pushed_at": "2022-11-26T19:34:33Z",
+    "description": "An ffxi windower addon to automatically assist a party member in combat",
+    "addon_dirs": []
+  },
+  {
     "repo": "Technyze/XIVHotbar2",
     "stars": 13,
     "pushed_at": "2023-03-12T03:29:46Z",
@@ -523,13 +592,6 @@
       "priv_res",
       "themes"
     ]
-  },
-  {
-    "repo": "ekrividus/autoAssist",
-    "stars": 13,
-    "pushed_at": "2022-11-26T19:34:33Z",
-    "description": "An ffxi windower addon to automatically assist a party member in combat",
-    "addon_dirs": []
   },
   {
     "repo": "DiscipleOfEris/Windower4Addons",
@@ -553,11 +615,18 @@
   {
     "repo": "HiPotionQ8/XIchecklist",
     "stars": 4,
-    "pushed_at": "2026-04-22T12:46:35Z",
+    "pushed_at": "2026-04-23T09:57:29Z",
     "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
     "addon_dirs": [
       "XIchecklist"
     ]
+  },
+  {
+    "repo": "onimitch/ffxi-zonename",
+    "stars": 4,
+    "pushed_at": "2026-04-05T14:44:54Z",
+    "description": "This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.",
+    "addon_dirs": []
   },
   {
     "repo": "Bryenne-Sylph/tourist",
@@ -567,5 +636,35 @@
     "addon_dirs": [
       "tourist"
     ]
+  },
+  {
+    "repo": "SQLCommit/GMTools",
+    "stars": 2,
+    "pushed_at": "2026-03-07T16:05:59Z",
+    "description": "FFXI - Ashita v4.3 Addon - LSB GM Command Helper",
+    "addon_dirs": []
+  },
+  {
+    "repo": "SQLCommit/LootScope",
+    "stars": 2,
+    "pushed_at": "2026-03-30T12:56:07Z",
+    "description": "FFXI - Ashita v4.3 Addon - Loot Drop Tracker",
+    "addon_dirs": [
+      "data"
+    ]
+  },
+  {
+    "repo": "SQLCommit/MemScope",
+    "stars": 2,
+    "pushed_at": "2026-03-07T16:06:09Z",
+    "description": "FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage",
+    "addon_dirs": []
+  },
+  {
+    "repo": "SQLCommit/ZoneLines",
+    "stars": 2,
+    "pushed_at": "2026-03-20T01:38:26Z",
+    "description": "FFXI - Ashita v4.3 Addon - Zone Line Visualizer",
+    "addon_dirs": []
   }
 ]


### PR DESCRIPTION
## Summary
4h repository maintenance sync for FFXI addon landscape artifacts.

### Added repositories
- `iLVL-Key/FFXI`
- `mousseng/xitools`
- `Tylas11/XivParty`
- `onimitch/ffxi-zonename`
- `SQLCommit/LootScope`
- `SQLCommit/ZoneLines`
- `SQLCommit/MemScope`
- `SQLCommit/GMTools`

### Updated repositories
- Refreshed stars, `pushed_at`, and descriptions via GitHub API for all indexed repos.

### Newly added addon entries (normalized)
`attend`, `bars`, `battleplan`, `bluspells`, `callouts`, `chatty`, `colure`, `dxui`, `emotes`, `exorcist`, `ffxi-zonename`, `gaolplan`, `gmtools`, `helper`, `imrecast`, `informer`, `jingle`, `leaderboard`, `llmchat`, `loggers`, `memscope`, `minimap-helper`, `rcheck`, `readycheck`, `relicge`, `repl`, `strats`, `sweeper`, `taskbar`, `trials`, `vanafacts`, `vanapad`, `vanity`, `wheel`, `xitools`, `znmtracker`, `zonelines`

### Removed/stale entries
- Repos removed: none
- Addons removed: none

## Confidence notes
- **High confidence**: repo existence/metadata (`stars`, `pushed_at`) from GitHub API.
- **Medium confidence**: single-purpose repo→addon mapping.
- **Lower confidence**: multi-addon folder discovery may include support-module directories in some repos.

## Validation
- `python3 -m json.tool ffxi_addons_index_raw.json`
- `python3 -m json.tool ffxi-addon-catalog-normalized.json`
- CSV regenerated and row-count checked (`295` rows)

## Scope guard
This PR is intentionally limited to catalog/index/docs sync artifacts for the 4h job.
