### PR TITLE
chore(sync): 4h catalog refresh (2026-04-24 0000 UTC)

### DIFF
--- a/docs/sync-2026-04-24-0000.md
+++ b/docs/sync-2026-04-24-0000.md
@@ -1,0 +1,50 @@
+# 4h Sync Report — 2026-04-24 00:00 UTC
+
+## Scope
+Catalog/index/docs maintenance only:
+- `ffxi_addons_index_raw.json`
+- `ffxi-addon-catalog-normalized.json`
+- `ffxi-addon-catalog-normalized.csv`
+- `docs/sync-2026-04-24-0000.md`
+
+## Repository deltas
+### Added repos
+- `Phayde/Windower-addons`
+- `Lydya-nick77/readycheck`
+- `BagTown/vanaclock`
+- `LordAttilas/FastTarget`
+- `ariel-logos/FancyTrusts`
+- `Gol-exe/closetCleaner2`
+- `patheed-ffxi/weeklier`
+
+### Updated repo metadata
+- Metadata refreshed for newly added repos (stars, `pushed_at`, descriptions).
+
+### Removed repos
+- None in this sync.
+
+## Addon deltas (normalized catalog)
+### Newly added addon entries
+- `digskill`
+- `smarttarget`
+- `trashit`
+- `readycheck`
+- `vanaclock`
+- `vanatime`
+- `fasttarget`
+- `fancytrusts`
+- `closetcleaner2`
+- `luaparser`
+- `weeklier`
+
+### Removed/stale addon entries
+- None removed in this pass.
+
+## Confidence notes
+- **High confidence**: repo existence + metadata via GitHub API for the added repos.
+- **Medium confidence**: addon extraction for multi-addon collections (`Phayde/Windower-addons`) where directories map to addon names.
+- **Lower confidence**: single-repo helper Lua filenames can be ambiguous (e.g., `vanatime`, `luaparser` may be support modules vs standalone addons).
+
+## Validation
+- JSON artifacts parse cleanly (`python3 -m json.tool`).
+- CSV regenerated from normalized JSON and row count matches JSON entry count.

--- a/ffxi-addon-catalog-normalized.csv
+++ b/ffxi-addon-catalog-normalized.csv
@@ -1,278 +1,10 @@
 addon_key,addon_name,category,repos,repo_count,best_repo_stars,freshness_max,opportunity_score,description,description_source,description_confidence
-xipivot,XIpivot,general_qol,HealsCodes/XIPivot,1,61,5,4.83,FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs,https://github.com/HealsCodes/XIPivot,medium
-trust,Trust,automation,cyritegamestudios/trust,1,49,5,4.83,Windower 4 addon for FFXI to automate your character in battle.,https://github.com/cyritegamestudios/trust,medium
-xivparty,XIvparty,ui_gear,Tylas11/XivParty,1,47,5,4.83,A party list addon for Windower 4.,https://github.com/Tylas11/XivParty,medium
-atreplace,Atreplace,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-augments,Augments,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-chatfix,Chatfix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-clevel,Clevel,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-collector,Collector,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-dramagen,Dramagen,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-gilbox,Gilbox,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-indinope,Indinope,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-jobinit,Jobinit,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-kaomoji,Kaomoji,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-menufix,Menufix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-mousehalo,Mousehalo,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-ondemand,Ondemand,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-position_manager,Position Manager,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-readable,Readable,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-safeoboro,Safeoboro,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-silttracker,Silttracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-smeagol,Smeagol,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-special,Special,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-tellapart,Tellapart,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-tellfix,Tellfix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-tiptoes,Tiptoes,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-tpsreport,Tpsreport,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-trialtracker,Trialtracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-useall,Useall,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-waveback,Waveback,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-weathermon,Weathermon,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-witnessprotection,Witnessprotection,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-bluspells,Bluspells,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-chatty,Chatty,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-colure,Colure,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-dxui,Dxui,ui_gear,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-imrecast,Imrecast,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-loggers,Loggers,diagnostics,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-minimap-helper,Minimap Helper,automation,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-rcheck,Rcheck,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-relicge,Relicge,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-repl,Repl,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-strats,Strats,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-trials,Trials,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-wheel,Wheel,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-xitools,XItools,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-attend,Attend,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-bars,Bars,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-battleplan,Battleplan,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-callouts,Callouts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-emotes,Emotes,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-exorcist,Exorcist,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-gaolplan,Gaolplan,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-helper,Helper,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-informer,Informer,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-jingle,Jingle,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-leaderboard,Leaderboard,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-llmchat,Llmchat,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-readycheck,Readycheck,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-sweeper,Sweeper,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-taskbar,Taskbar,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-vanafacts,Vanafacts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-vanapad,Vanapad,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-vanity,Vanity,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-znmtracker,Znmtracker,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-addons,Addons,diagnostics,HealsCodes/statustimers,1,15,5,4.83,Statustimers for Ashita v4,https://github.com/HealsCodes/statustimers,medium
-ffxi-zonename,FFXI Zonename,travel_navigation,onimitch/ffxi-zonename,1,4,5,4.83,This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.,https://github.com/onimitch/ffxi-zonename,medium
-xichecklist,XIchecklist,travel_navigation,HiPotionQ8/XIchecklist,1,4,5,4.83,"windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",https://github.com/HiPotionQ8/XIchecklist,medium
-tourist,Tourist,travel_navigation,Bryenne-Sylph/tourist,1,3,5,4.83,An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ,https://github.com/Bryenne-Sylph/tourist,medium
-gmtools,Gmtools,automation,SQLCommit/GMTools,1,2,5,4.83,FFXI - Ashita v4.3 Addon - LSB GM Command Helper,https://github.com/SQLCommit/GMTools,medium
-lootscope,Lootscope,economy_inventory,SQLCommit/LootScope,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Loot Drop Tracker,https://github.com/SQLCommit/LootScope,medium
-memscope,Memscope,diagnostics,SQLCommit/MemScope,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage,https://github.com/SQLCommit/MemScope,medium
-zonelines,Zonelines,travel_navigation,SQLCommit/ZoneLines,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Zone Line Visualizer,https://github.com/SQLCommit/ZoneLines,medium
-debuff-tracker,Debuff Tracker,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-menus,Menus,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-scanzone,Scanzone,travel_navigation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-turnaround,Turnaround,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-autodnc,Autodnc,automation,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-chococard,Chococard,general_qol,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-questlog,Questlog,general_qol,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-packetviewerlogviewer,Packetviewerlogviewer,diagnostics,ZeromusXYZ/PacketViewerLogViewer,1,17,2,3.78,PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp,https://github.com/ZeromusXYZ/PacketViewerLogViewer,medium
-ui,Ui,ui_gear,AliekberFFXI/xivcrossbar,1,17,2,3.78,FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar,https://github.com/AliekberFFXI/xivcrossbar,medium
-bursting,Bursting,general_qol,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
-crystaltrader,Crystaltrader,economy_inventory,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
-quicktrade_2,Quicktrade 2,ui_gear,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
-autoassist,Autoassist,automation,ekrividus/autoAssist,1,13,2,3.78,An ffxi windower addon to automatically assist a party member in combat,https://github.com/ekrividus/autoAssist,medium
-xivhotbar2,XIvhotbar2,ui_gear,Technyze/XIVHotbar2,1,13,2,3.78,,,low
-assist,Assist,automation,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-eradebuffed,Eradebuffed,combat_automation,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-eradistanceplus,Eradistanceplus,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-erainfobar,Erainfobar,ui_gear,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-erajobchange,Erajobchange,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-eramobdrops,Eramobdrops,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-eramoblevel,Eramoblevel,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-erapointwatch,Erapointwatch,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-erascoreboard,Erascoreboard,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-fastfollow,Fastfollow,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-clickfind,Clickfind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-dupefind,Dupefind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-friendzone,Friendzone,travel_navigation,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-omen,Omen,general_qol,Icydeath/ffxi-addons;mousseng/xitools,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-posfind,Posfind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-statsearch,Statsearch,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-superwarp,Superwarp,travel_navigation,AkadenTK/superwarp;Icydeath/ffxi-addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-ambuloot,Ambuloot,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-attackid,Attackid,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-attackwithme,Attackwithme,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autochain,Autochain,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autopup,Autopup,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autoraise,Autoraise,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autoskillchain,Autoskillchain,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autounm,Autounm,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autovw,Autovw,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autowatch,Autowatch,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-blist,Blist,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-canteen,Canteen,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-capetrader,Capetrader,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-charmed,Charmed,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-checkparam,Checkparam,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-crb_addon,Crb Addon,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-cureplease_addon,Cureplease Addon,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-currencies,Currencies,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-distanceplus,Distanceplus,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-drop,Drop,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-eschachest,Eschachest,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-export_items,Export Items,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-ffxikeys,FFXIkeys,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-finalalert,Finalalert,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-followme,Followme,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-giltracker,Giltracker,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-jobchange,Jobchange,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-locke,Locke,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-lockpick,Lockpick,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-maga,Maga,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-masstrade,Masstrade,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-moveitems,Moveitems,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-myhome,Myhome,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-myomen,Myomen,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-nnitimer,Nnitimer,diagnostics,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-noknock,Noknock,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-oneoffs,Oneoffs,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-partypets,Partypets,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-petparty,Petparty,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-positions,Positions,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-repeater,Repeater,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-roe,Roe,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-rolldistance,Rolldistance,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-rtfm,Rtfm,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-runicportal,Runicportal,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-schskillchain,Schskillchain,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-scriptedextender,Scriptedextender,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-sendalltarget,Sendalltarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-settarget,Settarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-simpleassist,Simpleassist,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-sirpopalot,Sirpopalot,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-smarttarget,Smarttarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-spellspammer,Spellspammer,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-stars,Stars,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-synergy,Synergy,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-targeter,Targeter,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-targetinfoex,Targetinfoex,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-targetplus,Targetplus,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-thfknife,Thfknife,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-tonic,Tonic,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-trader,Trader,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-triggers,Triggers,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-valkyrie,Valkyrie,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-voidwalker,Voidwalker,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-voidwatch,Voidwatch,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-vwpop,Vwpop,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-warpmenu,Warpmenu,travel_navigation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-where,Where,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-widescantool,Widescantool,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-woehelper,Woehelper,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-xivcrossbar,XIvcrossbar,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-zenimonsnap,Zenimonsnap,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-zonename,Zonename,travel_navigation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-enemybar2,Enemybar2,ui_gear,AkadenTK/enemybar2,1,19,1,3.43,Evolution of the simpler Windower addon that displays a target health bar prominently onscreen,https://github.com/AkadenTK/enemybar2,medium
-ase,Ase,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-autoinvite,Autoinvite,automation,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-broseem,Broseem,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-impalert,Impalert,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-pet_fix,Pet Fix,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-plugin_manager,Plugin Manager,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-rollbot,Rollbot,automation,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-skilluptracker,Skilluptracker,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-stna,Stna,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-stopwatch,Stopwatch,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-text,Text,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-translate,Translate,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-xivhotbar,XIvhotbar,ui_gear,Akirane/XIVHotbar,1,18,1,3.43,,,low
-barfiller,Barfiller,ui_gear,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-chars,Chars,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-chatlink,Chatlink,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-enemybar,Enemybar,ui_gear,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-ffxicaddieprovider,FFXIcaddieprovider,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-highlight,Highlight,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-inforeplacer,Inforeplacer,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-lazy,Lazy,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-nostrum,Nostrum,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-ohshi,Ohshi,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-plasmon,Plasmon,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-reive,Reive,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-rhombus,Rhombus,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-salvage2,Salvage2,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-satacast,Satacast,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-setbgm,Setbgm,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-strathelper,Strathelper,automation,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-taps,Taps,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-targetinfo,Targetinfo,combat_automation,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-truesight,Truesight,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-visiblefavor,Visiblefavor,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-yush,Yush,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-skillchain,Skillchain,combat_automation,Lygre/addons;mousseng/xitools;mverteuil/windower4-addons,3,29,5,3.26,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-allseeingeye,Allseeingeye,general_qol,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-equipviewer,Equipviewer,automation,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-partybuffs,Partybuffs,automation,Lygre/addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-react,React,automation,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-autocor,Autocor,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-autogeo,Autogeo,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-chatman,Chatman,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-htmb,Htmb,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-porterpacker,Porterpacker,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-singer,Singer,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-tradenpc,Tradenpc,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-magicassistant,Magicassistant,automation,Icydeath/ffxi-addons;ValokAsura/WindowerAddons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-quicktrade,Quicktrade,ui_gear,Icydeath/ffxi-addons;ValokAsura/WindowerAddons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-sendtarget,Sendtarget,combat_automation,DiscipleOfEris/Windower4Addons;Icydeath/ffxi-addons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-parse,Parse,diagnostics,Lygre/addons;flippant/parse,2,18,2,2.66,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-anchor,Anchor,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autocontrol,Autocontrol,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autojoin,Autojoin,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autows,Autows,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-azuresets,Azuresets,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-clock,Clock,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-dostuff,Dostuff,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-dynamishelper,Dynamishelper,automation,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-fisher,Fisher,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-lottery,Lottery,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-macrochanger,Macrochanger,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-porter,Porter,economy_inventory,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-send,Send,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-silence,Silence,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-subtarget,Subtarget,combat_automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-thtracker,Thtracker,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-timestamp,Timestamp,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-treasurepool,Treasurepool,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autosynth,Autosynth,automation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-bluguide,Bluguide,travel_navigation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-boxdestroyer,Boxdestroyer,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-debuffed,Debuffed,combat_automation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-digger,Digger,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-distance,Distance,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-gametime,Gametime,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-instals,Instals,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-latentchecker,Latentchecker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-linker,Linker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-ohnoyoudont,Ohnoyoudont,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-opensesame,Opensesame,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-packetviewer,Packetviewer,diagnostics,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-pettp,Pettp,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-pricer,Pricer,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-rolltracker,Rolltracker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-scoreboard,Scoreboard,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-speedchecker,Speedchecker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-spellcheck,Spellcheck,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-sprint,Sprint,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-synthall,Synthall,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-update,Update,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-skillchains,Skillchains,combat_automation,Icydeath/ffxi-addons;Ivaar/Skillchains;Lygre/addons;mverteuil/windower4-addons,4,69,3,2.27,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low
-auctionhelper,Auctionhelper,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons,3,79,2,2.21,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-trade,Trade,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons,3,79,2,2.21,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
 fastcs,Fastcs,general_qol,Icydeath/ffxi-addons;Lygre/addons;ProjectTako/ffxi-addons;mverteuil/windower4-addons,4,99,2,1.92,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,low
+healbot,Healbot,automation,Icydeath/ffxi-addons;Lygre/addons;lorand-ffxi/HealBot;mverteuil/windower4-addons,4,69,1,1.57,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low
 sellnpc,Sellnpc,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons;mverteuil/windower4-addons,4,79,2,1.92,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,low
+skillchains,Skillchains,combat_automation,Icydeath/ffxi-addons;Ivaar/Skillchains;Lygre/addons;mverteuil/windower4-addons,4,69,3,2.27,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low
 aecho,Aecho,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+auctionhelper,Auctionhelper,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons,3,79,2,2.21,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
 autora,Autora,automation,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 battlemod,Battlemod,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 cancel,Cancel,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
@@ -289,8 +21,285 @@ organizer,Organizer,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/wind
 pointwatch,Pointwatch,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 pouches,Pouches,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 shortcuts,Shortcuts,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+skillchain,Skillchain,combat_automation,Lygre/addons;mousseng/xitools;mverteuil/windower4-addons,3,29,5,3.26,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
 sparks,Sparks,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 tparty,Tparty,ui_gear,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+trade,Trade,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons,3,79,2,2.21,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
 treasury,Treasury,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 zonetimer,Zonetimer,travel_navigation,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-healbot,Healbot,automation,Icydeath/ffxi-addons;Lygre/addons;lorand-ffxi/HealBot;mverteuil/windower4-addons,4,69,1,1.57,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low
+allseeingeye,Allseeingeye,general_qol,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+anchor,Anchor,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autocontrol,Autocontrol,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autocor,Autocor,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+autogeo,Autogeo,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+autojoin,Autojoin,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autosynth,Autosynth,automation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+autows,Autows,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+azuresets,Azuresets,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+bluguide,Bluguide,travel_navigation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+boxdestroyer,Boxdestroyer,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+chatman,Chatman,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+clickfind,Clickfind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+clock,Clock,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+debuffed,Debuffed,combat_automation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+digger,Digger,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+distance,Distance,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+dostuff,Dostuff,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+dupefind,Dupefind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+dynamishelper,Dynamishelper,automation,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+equipviewer,Equipviewer,automation,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+fisher,Fisher,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+friendzone,Friendzone,travel_navigation,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+gametime,Gametime,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+htmb,Htmb,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+instals,Instals,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+latentchecker,Latentchecker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+linker,Linker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+lottery,Lottery,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+macrochanger,Macrochanger,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+magicassistant,Magicassistant,automation,Icydeath/ffxi-addons;ValokAsura/WindowerAddons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+ohnoyoudont,Ohnoyoudont,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+omen,Omen,general_qol,Icydeath/ffxi-addons;mousseng/xitools,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+opensesame,Opensesame,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+packetviewer,Packetviewer,diagnostics,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+parse,Parse,diagnostics,Lygre/addons;flippant/parse,2,18,2,2.66,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+partybuffs,Partybuffs,automation,Lygre/addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+pettp,Pettp,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+porter,Porter,economy_inventory,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+porterpacker,Porterpacker,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+posfind,Posfind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+pricer,Pricer,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+quicktrade,Quicktrade,ui_gear,Icydeath/ffxi-addons;ValokAsura/WindowerAddons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+react,React,automation,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+readycheck,Readycheck,general_qol,Lydya-nick77/readycheck;iLVL-Key/FFXI,2,22,5,3.4,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+rolltracker,Rolltracker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+scoreboard,Scoreboard,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+send,Send,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+sendtarget,Sendtarget,combat_automation,DiscipleOfEris/Windower4Addons;Icydeath/ffxi-addons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+silence,Silence,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+singer,Singer,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+smarttarget,Smarttarget,combat_automation,Icydeath/ffxi-addons;Phayde/Windower-addons,2,69,5,3.4,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+speedchecker,Speedchecker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+spellcheck,Spellcheck,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+sprint,Sprint,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+statsearch,Statsearch,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+subtarget,Subtarget,combat_automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+superwarp,Superwarp,travel_navigation,AkadenTK/superwarp;Icydeath/ffxi-addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+synthall,Synthall,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+thtracker,Thtracker,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+timestamp,Timestamp,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+tradenpc,Tradenpc,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+treasurepool,Treasurepool,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+update,Update,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+addons,Addons,diagnostics,HealsCodes/statustimers,1,15,5,4.83,Statustimers for Ashita v4,https://github.com/HealsCodes/statustimers,medium
+ambuloot,Ambuloot,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+ase,Ase,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+assist,Assist,automation,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+atreplace,Atreplace,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+attackid,Attackid,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+attackwithme,Attackwithme,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+attend,Attend,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+augments,Augments,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+autoassist,Autoassist,automation,ekrividus/autoAssist,1,13,2,3.78,An ffxi windower addon to automatically assist a party member in combat,https://github.com/ekrividus/autoAssist,medium
+autochain,Autochain,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autodnc,Autodnc,automation,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+autoinvite,Autoinvite,automation,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+autopup,Autopup,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autoraise,Autoraise,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autoskillchain,Autoskillchain,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autounm,Autounm,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autovw,Autovw,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+autowatch,Autowatch,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+barfiller,Barfiller,ui_gear,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+bars,Bars,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+battleplan,Battleplan,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+blist,Blist,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+bluspells,Bluspells,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+broseem,Broseem,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+bursting,Bursting,general_qol,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
+callouts,Callouts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+canteen,Canteen,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+capetrader,Capetrader,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+charmed,Charmed,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+chars,Chars,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+chatfix,Chatfix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+chatlink,Chatlink,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+chatty,Chatty,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+checkparam,Checkparam,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+chococard,Chococard,general_qol,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+clevel,Clevel,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+closetcleaner2,ClosetLeaner2,economy_inventory,Gol-exe/closetCleaner2,1,0,5,4.2,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,low
+collector,Collector,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+colure,Colure,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+crb_addon,Crb Addon,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+crystaltrader,Crystaltrader,economy_inventory,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
+cureplease_addon,Cureplease Addon,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+currencies,Currencies,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+debuff-tracker,Debuff Tracker,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+digskill,Digskill,general_qol,Phayde/Windower-addons,1,1,5,4.2,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,low
+distanceplus,Distanceplus,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+dramagen,Dramagen,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+drop,Drop,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+dxui,Dxui,ui_gear,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+emotes,Emotes,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+enemybar,Enemybar,ui_gear,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+enemybar2,Enemybar2,ui_gear,AkadenTK/enemybar2,1,19,1,3.43,Evolution of the simpler Windower addon that displays a target health bar prominently onscreen,https://github.com/AkadenTK/enemybar2,medium
+eradebuffed,Eradebuffed,combat_automation,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+eradistanceplus,Eradistanceplus,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+erainfobar,Erainfobar,ui_gear,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+erajobchange,Erajobchange,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+eramobdrops,Eramobdrops,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+eramoblevel,Eramoblevel,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+erapointwatch,Erapointwatch,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+erascoreboard,Erascoreboard,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+eschachest,Eschachest,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+exorcist,Exorcist,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+export_items,Export Items,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+fancytrusts,AncyRusts,combat_automation,ariel-logos/FancyTrusts,1,5,5,4.2,A fancy UI to manage trusts,https://github.com/ariel-logos/FancyTrusts,low
+fastfollow,Fastfollow,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
+fasttarget,AstArget,ui_gear,LordAttilas/FastTarget,1,0,5,4.2,Windower 4 addon for FFXI that allow quicker target change,https://github.com/LordAttilas/FastTarget,low
+ffxi-zonename,FFXI Zonename,travel_navigation,onimitch/ffxi-zonename,1,4,5,4.83,This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.,https://github.com/onimitch/ffxi-zonename,medium
+ffxicaddieprovider,FFXIcaddieprovider,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+ffxikeys,FFXIkeys,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+finalalert,Finalalert,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+followme,Followme,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+gaolplan,Gaolplan,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+gilbox,Gilbox,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+giltracker,Giltracker,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+gmtools,Gmtools,automation,SQLCommit/GMTools,1,2,5,4.83,FFXI - Ashita v4.3 Addon - LSB GM Command Helper,https://github.com/SQLCommit/GMTools,medium
+helper,Helper,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+highlight,Highlight,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+impalert,Impalert,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+imrecast,Imrecast,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+indinope,Indinope,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+inforeplacer,Inforeplacer,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+informer,Informer,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+jingle,Jingle,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+jobchange,Jobchange,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+jobinit,Jobinit,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+kaomoji,Kaomoji,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+lazy,Lazy,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+leaderboard,Leaderboard,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+llmchat,Llmchat,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+locke,Locke,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+lockpick,Lockpick,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+loggers,Loggers,diagnostics,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+lootscope,Lootscope,economy_inventory,SQLCommit/LootScope,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Loot Drop Tracker,https://github.com/SQLCommit/LootScope,medium
+luaparser,LuaArser,diagnostics,Gol-exe/closetCleaner2,1,0,5,4.2,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,low
+maga,Maga,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+masstrade,Masstrade,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+memscope,Memscope,diagnostics,SQLCommit/MemScope,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage,https://github.com/SQLCommit/MemScope,medium
+menufix,Menufix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+menus,Menus,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+minimap-helper,Minimap Helper,automation,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+mousehalo,Mousehalo,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+moveitems,Moveitems,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+myhome,Myhome,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+myomen,Myomen,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+nnitimer,Nnitimer,diagnostics,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+noknock,Noknock,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+nostrum,Nostrum,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+ohshi,Ohshi,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+ondemand,Ondemand,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+oneoffs,Oneoffs,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+packetviewerlogviewer,Packetviewerlogviewer,diagnostics,ZeromusXYZ/PacketViewerLogViewer,1,17,2,3.78,PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp,https://github.com/ZeromusXYZ/PacketViewerLogViewer,medium
+partypets,Partypets,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+pet_fix,Pet Fix,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+petparty,Petparty,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+plasmon,Plasmon,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+plugin_manager,Plugin Manager,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+position_manager,Position Manager,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+positions,Positions,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+questlog,Questlog,general_qol,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
+quicktrade_2,Quicktrade 2,ui_gear,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
+rcheck,Rcheck,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+readable,Readable,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+reive,Reive,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+relicge,Relicge,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+repeater,Repeater,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+repl,Repl,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+rhombus,Rhombus,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+roe,Roe,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+rollbot,Rollbot,automation,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+rolldistance,Rolldistance,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+rtfm,Rtfm,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+runicportal,Runicportal,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+safeoboro,Safeoboro,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+salvage2,Salvage2,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+satacast,Satacast,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+scanzone,Scanzone,travel_navigation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+schskillchain,Schskillchain,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+scriptedextender,Scriptedextender,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+sendalltarget,Sendalltarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+setbgm,Setbgm,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+settarget,Settarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+silttracker,Silttracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+simpleassist,Simpleassist,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+sirpopalot,Sirpopalot,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+skilluptracker,Skilluptracker,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+smeagol,Smeagol,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+special,Special,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+spellspammer,Spellspammer,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+stars,Stars,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+stna,Stna,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+stopwatch,Stopwatch,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+strathelper,Strathelper,automation,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+strats,Strats,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+sweeper,Sweeper,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+synergy,Synergy,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+taps,Taps,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+targeter,Targeter,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+targetinfo,Targetinfo,combat_automation,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+targetinfoex,Targetinfoex,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+targetplus,Targetplus,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+taskbar,Taskbar,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+tellapart,Tellapart,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+tellfix,Tellfix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+text,Text,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+thfknife,Thfknife,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+tiptoes,Tiptoes,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+tonic,Tonic,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+tourist,Tourist,travel_navigation,Bryenne-Sylph/tourist,1,3,5,4.83,An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ,https://github.com/Bryenne-Sylph/tourist,medium
+tpsreport,Tpsreport,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+trader,Trader,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+translate,Translate,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
+trashit,Trashit,general_qol,Phayde/Windower-addons,1,1,5,4.2,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,low
+trials,Trials,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+trialtracker,Trialtracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+triggers,Triggers,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+truesight,Truesight,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+trust,Trust,automation,cyritegamestudios/trust,1,49,5,4.83,Windower 4 addon for FFXI to automate your character in battle.,https://github.com/cyritegamestudios/trust,medium
+turnaround,Turnaround,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
+ui,Ui,ui_gear,AliekberFFXI/xivcrossbar,1,17,2,3.78,FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar,https://github.com/AliekberFFXI/xivcrossbar,medium
+useall,Useall,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+valkyrie,Valkyrie,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+vanaclock,Vanaclock,travel_navigation,BagTown/vanaclock,1,3,5,4.2,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,low
+vanafacts,Vanafacts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+vanapad,Vanapad,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+vanatime,Vanatime,general_qol,BagTown/vanaclock,1,3,5,4.2,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,low
+vanity,Vanity,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+visiblefavor,Visiblefavor,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+voidwalker,Voidwalker,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+voidwatch,Voidwatch,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+vwpop,Vwpop,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+warpmenu,Warpmenu,travel_navigation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+waveback,Waveback,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+weathermon,Weathermon,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+weeklier,Weeklier,diagnostics,patheed-ffxi/weeklier,1,0,5,4.2,An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.,https://github.com/patheed-ffxi/weeklier,low
+wheel,Wheel,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+where,Where,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+widescantool,Widescantool,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+witnessprotection,Witnessprotection,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
+woehelper,Woehelper,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+xichecklist,XIchecklist,travel_navigation,HiPotionQ8/XIchecklist,1,4,5,4.83,"windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",https://github.com/HiPotionQ8/XIchecklist,medium
+xipivot,XIpivot,general_qol,HealsCodes/XIPivot,1,61,5,4.83,FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs,https://github.com/HealsCodes/XIPivot,medium
+xitools,XItools,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
+xivcrossbar,XIvcrossbar,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+xivhotbar,XIvhotbar,ui_gear,Akirane/XIVHotbar,1,18,1,3.43,,,low
+xivhotbar2,XIvhotbar2,ui_gear,Technyze/XIVHotbar2,1,13,2,3.78,,,low
+xivparty,XIvparty,ui_gear,Tylas11/XivParty,1,47,5,4.83,A party list addon for Windower 4.,https://github.com/Tylas11/XivParty,medium
+yush,Yush,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
+zenimonsnap,Zenimonsnap,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+znmtracker,Znmtracker,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+zonelines,Zonelines,travel_navigation,SQLCommit/ZoneLines,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Zone Line Visualizer,https://github.com/SQLCommit/ZoneLines,medium
+zonename,Zonename,travel_navigation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium

--- a/ffxi-addon-catalog-normalized.json
+++ b/ffxi-addon-catalog-normalized.json
@@ -1,4141 +1,5 @@
 [
   {
-    "addon_key": "xipivot",
-    "addon_name": "XIpivot",
-    "category": "general_qol",
-    "repos": [
-      "HealsCodes/XIPivot"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 61,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
-    "description_source": "https://github.com/HealsCodes/XIPivot",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "trust",
-    "addon_name": "Trust",
-    "category": "automation",
-    "repos": [
-      "cyritegamestudios/trust"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 49,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Windower 4 addon for FFXI to automate your character in battle.",
-    "description_source": "https://github.com/cyritegamestudios/trust",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xivparty",
-    "addon_name": "XIvparty",
-    "category": "ui_gear",
-    "repos": [
-      "Tylas11/XivParty"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 47,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "A party list addon for Windower 4.",
-    "description_source": "https://github.com/Tylas11/XivParty",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "atreplace",
-    "addon_name": "Atreplace",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "augments",
-    "addon_name": "Augments",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chatfix",
-    "addon_name": "Chatfix",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "clevel",
-    "addon_name": "Clevel",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "collector",
-    "addon_name": "Collector",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dramagen",
-    "addon_name": "Dramagen",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "gilbox",
-    "addon_name": "Gilbox",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "indinope",
-    "addon_name": "Indinope",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "jobinit",
-    "addon_name": "Jobinit",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "kaomoji",
-    "addon_name": "Kaomoji",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "menufix",
-    "addon_name": "Menufix",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "mousehalo",
-    "addon_name": "Mousehalo",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ondemand",
-    "addon_name": "Ondemand",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "position_manager",
-    "addon_name": "Position Manager",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "readable",
-    "addon_name": "Readable",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "safeoboro",
-    "addon_name": "Safeoboro",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "silttracker",
-    "addon_name": "Silttracker",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "smeagol",
-    "addon_name": "Smeagol",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "special",
-    "addon_name": "Special",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tellapart",
-    "addon_name": "Tellapart",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tellfix",
-    "addon_name": "Tellfix",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tiptoes",
-    "addon_name": "Tiptoes",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tpsreport",
-    "addon_name": "Tpsreport",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "trialtracker",
-    "addon_name": "Trialtracker",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "useall",
-    "addon_name": "Useall",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "waveback",
-    "addon_name": "Waveback",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "weathermon",
-    "addon_name": "Weathermon",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "witnessprotection",
-    "addon_name": "Witnessprotection",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "bluspells",
-    "addon_name": "Bluspells",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chatty",
-    "addon_name": "Chatty",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "colure",
-    "addon_name": "Colure",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dxui",
-    "addon_name": "Dxui",
-    "category": "ui_gear",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "imrecast",
-    "addon_name": "Imrecast",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "loggers",
-    "addon_name": "Loggers",
-    "category": "diagnostics",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "minimap-helper",
-    "addon_name": "Minimap Helper",
-    "category": "automation",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "rcheck",
-    "addon_name": "Rcheck",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "relicge",
-    "addon_name": "Relicge",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "repl",
-    "addon_name": "Repl",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "strats",
-    "addon_name": "Strats",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "trials",
-    "addon_name": "Trials",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "wheel",
-    "addon_name": "Wheel",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xitools",
-    "addon_name": "XItools",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "attend",
-    "addon_name": "Attend",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "bars",
-    "addon_name": "Bars",
-    "category": "ui_gear",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "battleplan",
-    "addon_name": "Battleplan",
-    "category": "automation",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "callouts",
-    "addon_name": "Callouts",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "emotes",
-    "addon_name": "Emotes",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "exorcist",
-    "addon_name": "Exorcist",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "gaolplan",
-    "addon_name": "Gaolplan",
-    "category": "automation",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "helper",
-    "addon_name": "Helper",
-    "category": "automation",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "informer",
-    "addon_name": "Informer",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "jingle",
-    "addon_name": "Jingle",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "leaderboard",
-    "addon_name": "Leaderboard",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "llmchat",
-    "addon_name": "Llmchat",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "readycheck",
-    "addon_name": "Readycheck",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "sweeper",
-    "addon_name": "Sweeper",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "taskbar",
-    "addon_name": "Taskbar",
-    "category": "ui_gear",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "vanafacts",
-    "addon_name": "Vanafacts",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "vanapad",
-    "addon_name": "Vanapad",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "vanity",
-    "addon_name": "Vanity",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "znmtracker",
-    "addon_name": "Znmtracker",
-    "category": "general_qol",
-    "repos": [
-      "iLVL-Key/FFXI"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "addons",
-    "addon_name": "Addons",
-    "category": "diagnostics",
-    "repos": [
-      "HealsCodes/statustimers"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 15,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Statustimers for Ashita v4",
-    "description_source": "https://github.com/HealsCodes/statustimers",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ffxi-zonename",
-    "addon_name": "FFXI Zonename",
-    "category": "travel_navigation",
-    "repos": [
-      "onimitch/ffxi-zonename"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 4,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.",
-    "description_source": "https://github.com/onimitch/ffxi-zonename",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xichecklist",
-    "addon_name": "XIchecklist",
-    "category": "travel_navigation",
-    "repos": [
-      "HiPotionQ8/XIchecklist"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 4,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
-    "description_source": "https://github.com/HiPotionQ8/XIchecklist",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tourist",
-    "addon_name": "Tourist",
-    "category": "travel_navigation",
-    "repos": [
-      "Bryenne-Sylph/tourist"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 3,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
-    "description_source": "https://github.com/Bryenne-Sylph/tourist",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "gmtools",
-    "addon_name": "Gmtools",
-    "category": "automation",
-    "repos": [
-      "SQLCommit/GMTools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 2,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "FFXI - Ashita v4.3 Addon - LSB GM Command Helper",
-    "description_source": "https://github.com/SQLCommit/GMTools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "lootscope",
-    "addon_name": "Lootscope",
-    "category": "economy_inventory",
-    "repos": [
-      "SQLCommit/LootScope"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 2,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "FFXI - Ashita v4.3 Addon - Loot Drop Tracker",
-    "description_source": "https://github.com/SQLCommit/LootScope",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "memscope",
-    "addon_name": "Memscope",
-    "category": "diagnostics",
-    "repos": [
-      "SQLCommit/MemScope"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 2,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage",
-    "description_source": "https://github.com/SQLCommit/MemScope",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "zonelines",
-    "addon_name": "Zonelines",
-    "category": "travel_navigation",
-    "repos": [
-      "SQLCommit/ZoneLines"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 2,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "FFXI - Ashita v4.3 Addon - Zone Line Visualizer",
-    "description_source": "https://github.com/SQLCommit/ZoneLines",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "debuff-tracker",
-    "addon_name": "Debuff Tracker",
-    "category": "automation",
-    "repos": [
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "menus",
-    "addon_name": "Menus",
-    "category": "automation",
-    "repos": [
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "scanzone",
-    "addon_name": "Scanzone",
-    "category": "travel_navigation",
-    "repos": [
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "turnaround",
-    "addon_name": "Turnaround",
-    "category": "automation",
-    "repos": [
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autodnc",
-    "addon_name": "Autodnc",
-    "category": "automation",
-    "repos": [
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chococard",
-    "addon_name": "Chococard",
-    "category": "general_qol",
-    "repos": [
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "questlog",
-    "addon_name": "Questlog",
-    "category": "general_qol",
-    "repos": [
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "packetviewerlogviewer",
-    "addon_name": "Packetviewerlogviewer",
-    "category": "diagnostics",
-    "repos": [
-      "ZeromusXYZ/PacketViewerLogViewer"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
-    "description_source": "https://github.com/ZeromusXYZ/PacketViewerLogViewer",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ui",
-    "addon_name": "Ui",
-    "category": "ui_gear",
-    "repos": [
-      "AliekberFFXI/xivcrossbar"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
-    "description_source": "https://github.com/AliekberFFXI/xivcrossbar",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "bursting",
-    "addon_name": "Bursting",
-    "category": "general_qol",
-    "repos": [
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 14,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "",
-    "description_source": "",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "crystaltrader",
-    "addon_name": "Crystaltrader",
-    "category": "economy_inventory",
-    "repos": [
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 14,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "",
-    "description_source": "",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "quicktrade_2",
-    "addon_name": "Quicktrade 2",
-    "category": "ui_gear",
-    "repos": [
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 14,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "",
-    "description_source": "",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "autoassist",
-    "addon_name": "Autoassist",
-    "category": "automation",
-    "repos": [
-      "ekrividus/autoAssist"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 13,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "An ffxi windower addon to automatically assist a party member in combat",
-    "description_source": "https://github.com/ekrividus/autoAssist",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xivhotbar2",
-    "addon_name": "XIvhotbar2",
-    "category": "ui_gear",
-    "repos": [
-      "Technyze/XIVHotbar2"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 13,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "",
-    "description_source": "",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "assist",
-    "addon_name": "Assist",
-    "category": "automation",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "eradebuffed",
-    "addon_name": "Eradebuffed",
-    "category": "combat_automation",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "eradistanceplus",
-    "addon_name": "Eradistanceplus",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "erainfobar",
-    "addon_name": "Erainfobar",
-    "category": "ui_gear",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "erajobchange",
-    "addon_name": "Erajobchange",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "eramobdrops",
-    "addon_name": "Eramobdrops",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "eramoblevel",
-    "addon_name": "Eramoblevel",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "erapointwatch",
-    "addon_name": "Erapointwatch",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "erascoreboard",
-    "addon_name": "Erascoreboard",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "fastfollow",
-    "addon_name": "Fastfollow",
-    "category": "general_qol",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "clickfind",
-    "addon_name": "Clickfind",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 5,
-    "opportunity_score": 3.71,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dupefind",
-    "addon_name": "Dupefind",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 5,
-    "opportunity_score": 3.71,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "friendzone",
-    "addon_name": "Friendzone",
-    "category": "travel_navigation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 5,
-    "opportunity_score": 3.71,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "omen",
-    "addon_name": "Omen",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mousseng/xitools"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 5,
-    "opportunity_score": 3.71,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "posfind",
-    "addon_name": "Posfind",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 5,
-    "opportunity_score": 3.71,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "statsearch",
-    "addon_name": "Statsearch",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 5,
-    "opportunity_score": 3.71,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "superwarp",
-    "addon_name": "Superwarp",
-    "category": "travel_navigation",
-    "repos": [
-      "AkadenTK/superwarp",
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 5,
-    "opportunity_score": 3.71,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ambuloot",
-    "addon_name": "Ambuloot",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "attackid",
-    "addon_name": "Attackid",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "attackwithme",
-    "addon_name": "Attackwithme",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autochain",
-    "addon_name": "Autochain",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autopup",
-    "addon_name": "Autopup",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autoraise",
-    "addon_name": "Autoraise",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autoskillchain",
-    "addon_name": "Autoskillchain",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autounm",
-    "addon_name": "Autounm",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autovw",
-    "addon_name": "Autovw",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autowatch",
-    "addon_name": "Autowatch",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "blist",
-    "addon_name": "Blist",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "canteen",
-    "addon_name": "Canteen",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "capetrader",
-    "addon_name": "Capetrader",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "charmed",
-    "addon_name": "Charmed",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "checkparam",
-    "addon_name": "Checkparam",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "crb_addon",
-    "addon_name": "Crb Addon",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "cureplease_addon",
-    "addon_name": "Cureplease Addon",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "currencies",
-    "addon_name": "Currencies",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "distanceplus",
-    "addon_name": "Distanceplus",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "drop",
-    "addon_name": "Drop",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "eschachest",
-    "addon_name": "Eschachest",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "export_items",
-    "addon_name": "Export Items",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ffxikeys",
-    "addon_name": "FFXIkeys",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "finalalert",
-    "addon_name": "Finalalert",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "followme",
-    "addon_name": "Followme",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "giltracker",
-    "addon_name": "Giltracker",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "jobchange",
-    "addon_name": "Jobchange",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "locke",
-    "addon_name": "Locke",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "lockpick",
-    "addon_name": "Lockpick",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "maga",
-    "addon_name": "Maga",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "masstrade",
-    "addon_name": "Masstrade",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "moveitems",
-    "addon_name": "Moveitems",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "myhome",
-    "addon_name": "Myhome",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "myomen",
-    "addon_name": "Myomen",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "nnitimer",
-    "addon_name": "Nnitimer",
-    "category": "diagnostics",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "noknock",
-    "addon_name": "Noknock",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "oneoffs",
-    "addon_name": "Oneoffs",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "partypets",
-    "addon_name": "Partypets",
-    "category": "ui_gear",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "petparty",
-    "addon_name": "Petparty",
-    "category": "ui_gear",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "positions",
-    "addon_name": "Positions",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "repeater",
-    "addon_name": "Repeater",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "roe",
-    "addon_name": "Roe",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "rolldistance",
-    "addon_name": "Rolldistance",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "rtfm",
-    "addon_name": "Rtfm",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "runicportal",
-    "addon_name": "Runicportal",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "schskillchain",
-    "addon_name": "Schskillchain",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "scriptedextender",
-    "addon_name": "Scriptedextender",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "sendalltarget",
-    "addon_name": "Sendalltarget",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "settarget",
-    "addon_name": "Settarget",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "simpleassist",
-    "addon_name": "Simpleassist",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "sirpopalot",
-    "addon_name": "Sirpopalot",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "smarttarget",
-    "addon_name": "Smarttarget",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "spellspammer",
-    "addon_name": "Spellspammer",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "stars",
-    "addon_name": "Stars",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "synergy",
-    "addon_name": "Synergy",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "targeter",
-    "addon_name": "Targeter",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "targetinfoex",
-    "addon_name": "Targetinfoex",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "targetplus",
-    "addon_name": "Targetplus",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "thfknife",
-    "addon_name": "Thfknife",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tonic",
-    "addon_name": "Tonic",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "trader",
-    "addon_name": "Trader",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "triggers",
-    "addon_name": "Triggers",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "valkyrie",
-    "addon_name": "Valkyrie",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "voidwalker",
-    "addon_name": "Voidwalker",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "voidwatch",
-    "addon_name": "Voidwatch",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "vwpop",
-    "addon_name": "Vwpop",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "warpmenu",
-    "addon_name": "Warpmenu",
-    "category": "travel_navigation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "where",
-    "addon_name": "Where",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "widescantool",
-    "addon_name": "Widescantool",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "woehelper",
-    "addon_name": "Woehelper",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xivcrossbar",
-    "addon_name": "XIvcrossbar",
-    "category": "ui_gear",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "zenimonsnap",
-    "addon_name": "Zenimonsnap",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "zonename",
-    "addon_name": "Zonename",
-    "category": "travel_navigation",
-    "repos": [
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "enemybar2",
-    "addon_name": "Enemybar2",
-    "category": "ui_gear",
-    "repos": [
-      "AkadenTK/enemybar2"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 19,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
-    "description_source": "https://github.com/AkadenTK/enemybar2",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ase",
-    "addon_name": "Ase",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autoinvite",
-    "addon_name": "Autoinvite",
-    "category": "automation",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "broseem",
-    "addon_name": "Broseem",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "impalert",
-    "addon_name": "Impalert",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "pet_fix",
-    "addon_name": "Pet Fix",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "plugin_manager",
-    "addon_name": "Plugin Manager",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "rollbot",
-    "addon_name": "Rollbot",
-    "category": "automation",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "skilluptracker",
-    "addon_name": "Skilluptracker",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "stna",
-    "addon_name": "Stna",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "stopwatch",
-    "addon_name": "Stopwatch",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "text",
-    "addon_name": "Text",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "translate",
-    "addon_name": "Translate",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xivhotbar",
-    "addon_name": "XIvhotbar",
-    "category": "ui_gear",
-    "repos": [
-      "Akirane/XIVHotbar"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "",
-    "description_source": "",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "barfiller",
-    "addon_name": "Barfiller",
-    "category": "ui_gear",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chars",
-    "addon_name": "Chars",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chatlink",
-    "addon_name": "Chatlink",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "enemybar",
-    "addon_name": "Enemybar",
-    "category": "ui_gear",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ffxicaddieprovider",
-    "addon_name": "FFXIcaddieprovider",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "highlight",
-    "addon_name": "Highlight",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "inforeplacer",
-    "addon_name": "Inforeplacer",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "lazy",
-    "addon_name": "Lazy",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "nostrum",
-    "addon_name": "Nostrum",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ohshi",
-    "addon_name": "Ohshi",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "plasmon",
-    "addon_name": "Plasmon",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "reive",
-    "addon_name": "Reive",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "rhombus",
-    "addon_name": "Rhombus",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "salvage2",
-    "addon_name": "Salvage2",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "satacast",
-    "addon_name": "Satacast",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "setbgm",
-    "addon_name": "Setbgm",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "strathelper",
-    "addon_name": "Strathelper",
-    "category": "automation",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "taps",
-    "addon_name": "Taps",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "targetinfo",
-    "addon_name": "Targetinfo",
-    "category": "combat_automation",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "truesight",
-    "addon_name": "Truesight",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "visiblefavor",
-    "addon_name": "Visiblefavor",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "yush",
-    "addon_name": "Yush",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "skillchain",
-    "addon_name": "Skillchain",
-    "category": "combat_automation",
-    "repos": [
-      "Lygre/addons",
-      "mousseng/xitools",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 3,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 3.26,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "allseeingeye",
-    "addon_name": "Allseeingeye",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "equipviewer",
-    "addon_name": "Equipviewer",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "partybuffs",
-    "addon_name": "Partybuffs",
-    "category": "automation",
-    "repos": [
-      "Lygre/addons",
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "react",
-    "addon_name": "React",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autocor",
-    "addon_name": "Autocor",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autogeo",
-    "addon_name": "Autogeo",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chatman",
-    "addon_name": "Chatman",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "htmb",
-    "addon_name": "Htmb",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "porterpacker",
-    "addon_name": "Porterpacker",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "singer",
-    "addon_name": "Singer",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tradenpc",
-    "addon_name": "Tradenpc",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "magicassistant",
-    "addon_name": "Magicassistant",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "quicktrade",
-    "addon_name": "Quicktrade",
-    "category": "ui_gear",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "sendtarget",
-    "addon_name": "Sendtarget",
-    "category": "combat_automation",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons",
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "parse",
-    "addon_name": "Parse",
-    "category": "diagnostics",
-    "repos": [
-      "Lygre/addons",
-      "flippant/parse"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "anchor",
-    "addon_name": "Anchor",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autocontrol",
-    "addon_name": "Autocontrol",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autojoin",
-    "addon_name": "Autojoin",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autows",
-    "addon_name": "Autows",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "azuresets",
-    "addon_name": "Azuresets",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "clock",
-    "addon_name": "Clock",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dostuff",
-    "addon_name": "Dostuff",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dynamishelper",
-    "addon_name": "Dynamishelper",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "fisher",
-    "addon_name": "Fisher",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "lottery",
-    "addon_name": "Lottery",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "macrochanger",
-    "addon_name": "Macrochanger",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "porter",
-    "addon_name": "Porter",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "send",
-    "addon_name": "Send",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "silence",
-    "addon_name": "Silence",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "subtarget",
-    "addon_name": "Subtarget",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "thtracker",
-    "addon_name": "Thtracker",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "timestamp",
-    "addon_name": "Timestamp",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "treasurepool",
-    "addon_name": "Treasurepool",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autosynth",
-    "addon_name": "Autosynth",
-    "category": "automation",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "bluguide",
-    "addon_name": "Bluguide",
-    "category": "travel_navigation",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "boxdestroyer",
-    "addon_name": "Boxdestroyer",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "debuffed",
-    "addon_name": "Debuffed",
-    "category": "combat_automation",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "digger",
-    "addon_name": "Digger",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "distance",
-    "addon_name": "Distance",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "gametime",
-    "addon_name": "Gametime",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "instals",
-    "addon_name": "Instals",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "latentchecker",
-    "addon_name": "Latentchecker",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "linker",
-    "addon_name": "Linker",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ohnoyoudont",
-    "addon_name": "Ohnoyoudont",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "opensesame",
-    "addon_name": "Opensesame",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "packetviewer",
-    "addon_name": "Packetviewer",
-    "category": "diagnostics",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "pettp",
-    "addon_name": "Pettp",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "pricer",
-    "addon_name": "Pricer",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "rolltracker",
-    "addon_name": "Rolltracker",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "scoreboard",
-    "addon_name": "Scoreboard",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "speedchecker",
-    "addon_name": "Speedchecker",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "spellcheck",
-    "addon_name": "Spellcheck",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "sprint",
-    "addon_name": "Sprint",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "synthall",
-    "addon_name": "Synthall",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "update",
-    "addon_name": "Update",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "skillchains",
-    "addon_name": "Skillchains",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Skillchains",
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 4,
-    "best_repo_stars": 69,
-    "freshness_max": 3,
-    "opportunity_score": 2.27,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "auctionhelper",
-    "addon_name": "Auctionhelper",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 3,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.21,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "trade",
-    "addon_name": "Trade",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 3,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.21,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
     "addon_key": "fastcs",
     "addon_name": "Fastcs",
     "category": "general_qol",
@@ -4151,6 +15,24 @@
     "opportunity_score": 1.92,
     "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
     "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "healbot",
+    "addon_name": "Healbot",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons",
+      "lorand-ffxi/HealBot",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 4,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 1.57,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "low"
   },
   {
@@ -4172,6 +54,24 @@
     "description_confidence": "low"
   },
   {
+    "addon_key": "skillchains",
+    "addon_name": "Skillchains",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Skillchains",
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 4,
+    "best_repo_stars": 69,
+    "freshness_max": 3,
+    "opportunity_score": 2.27,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "low"
+  },
+  {
     "addon_key": "aecho",
     "addon_name": "Aecho",
     "category": "general_qol",
@@ -4186,6 +86,23 @@
     "opportunity_score": 1.86,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "auctionhelper",
+    "addon_name": "Auctionhelper",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 3,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.21,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
     "description_confidence": "medium"
   },
   {
@@ -4461,6 +378,23 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "skillchain",
+    "addon_name": "Skillchain",
+    "category": "combat_automation",
+    "repos": [
+      "Lygre/addons",
+      "mousseng/xitools",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 3,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 3.26,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "sparks",
     "addon_name": "Sparks",
     "category": "general_qol",
@@ -4492,6 +426,23 @@
     "opportunity_score": 1.86,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trade",
+    "addon_name": "Trade",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 3,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.21,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
     "description_confidence": "medium"
   },
   {
@@ -4529,21 +480,4207 @@
     "description_confidence": "medium"
   },
   {
-    "addon_key": "healbot",
-    "addon_name": "Healbot",
+    "addon_key": "allseeingeye",
+    "addon_name": "Allseeingeye",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "anchor",
+    "addon_name": "Anchor",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autocontrol",
+    "addon_name": "Autocontrol",
     "category": "automation",
     "repos": [
       "Icydeath/ffxi-addons",
-      "Lygre/addons",
-      "lorand-ffxi/HealBot",
-      "mverteuil/windower4-addons"
+      "Lygre/addons"
     ],
-    "repo_count": 4,
+    "repo_count": 2,
     "best_repo_stars": 69,
     "freshness_max": 1,
-    "opportunity_score": 1.57,
+    "opportunity_score": 2.31,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autocor",
+    "addon_name": "Autocor",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autogeo",
+    "addon_name": "Autogeo",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autojoin",
+    "addon_name": "Autojoin",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autosynth",
+    "addon_name": "Autosynth",
+    "category": "automation",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autows",
+    "addon_name": "Autows",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "azuresets",
+    "addon_name": "Azuresets",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "bluguide",
+    "addon_name": "Bluguide",
+    "category": "travel_navigation",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "boxdestroyer",
+    "addon_name": "Boxdestroyer",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatman",
+    "addon_name": "Chatman",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "clickfind",
+    "addon_name": "Clickfind",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "clock",
+    "addon_name": "Clock",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "debuffed",
+    "addon_name": "Debuffed",
+    "category": "combat_automation",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "digger",
+    "addon_name": "Digger",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "distance",
+    "addon_name": "Distance",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dostuff",
+    "addon_name": "Dostuff",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dupefind",
+    "addon_name": "Dupefind",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dynamishelper",
+    "addon_name": "Dynamishelper",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "equipviewer",
+    "addon_name": "Equipviewer",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fisher",
+    "addon_name": "Fisher",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "friendzone",
+    "addon_name": "Friendzone",
+    "category": "travel_navigation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "gametime",
+    "addon_name": "Gametime",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "htmb",
+    "addon_name": "Htmb",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "instals",
+    "addon_name": "Instals",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "latentchecker",
+    "addon_name": "Latentchecker",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "linker",
+    "addon_name": "Linker",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "lottery",
+    "addon_name": "Lottery",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "macrochanger",
+    "addon_name": "Macrochanger",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "magicassistant",
+    "addon_name": "Magicassistant",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "ValokAsura/WindowerAddons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ohnoyoudont",
+    "addon_name": "Ohnoyoudont",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "omen",
+    "addon_name": "Omen",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mousseng/xitools"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "opensesame",
+    "addon_name": "Opensesame",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "packetviewer",
+    "addon_name": "Packetviewer",
+    "category": "diagnostics",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "parse",
+    "addon_name": "Parse",
+    "category": "diagnostics",
+    "repos": [
+      "Lygre/addons",
+      "flippant/parse"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "partybuffs",
+    "addon_name": "Partybuffs",
+    "category": "automation",
+    "repos": [
+      "Lygre/addons",
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "pettp",
+    "addon_name": "Pettp",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "porter",
+    "addon_name": "Porter",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "porterpacker",
+    "addon_name": "Porterpacker",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "posfind",
+    "addon_name": "Posfind",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "pricer",
+    "addon_name": "Pricer",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "quicktrade",
+    "addon_name": "Quicktrade",
+    "category": "ui_gear",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "ValokAsura/WindowerAddons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "react",
+    "addon_name": "React",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "readycheck",
+    "addon_name": "Readycheck",
+    "category": "general_qol",
+    "repos": [
+      "Lydya-nick77/readycheck",
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 3.4,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "rolltracker",
+    "addon_name": "Rolltracker",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "scoreboard",
+    "addon_name": "Scoreboard",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "send",
+    "addon_name": "Send",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "sendtarget",
+    "addon_name": "Sendtarget",
+    "category": "combat_automation",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons",
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "silence",
+    "addon_name": "Silence",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "singer",
+    "addon_name": "Singer",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "smarttarget",
+    "addon_name": "Smarttarget",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Phayde/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.4,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "speedchecker",
+    "addon_name": "Speedchecker",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "spellcheck",
+    "addon_name": "Spellcheck",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "sprint",
+    "addon_name": "Sprint",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "statsearch",
+    "addon_name": "Statsearch",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "subtarget",
+    "addon_name": "Subtarget",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "superwarp",
+    "addon_name": "Superwarp",
+    "category": "travel_navigation",
+    "repos": [
+      "AkadenTK/superwarp",
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "synthall",
+    "addon_name": "Synthall",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "thtracker",
+    "addon_name": "Thtracker",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "timestamp",
+    "addon_name": "Timestamp",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tradenpc",
+    "addon_name": "Tradenpc",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "treasurepool",
+    "addon_name": "Treasurepool",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "update",
+    "addon_name": "Update",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "addons",
+    "addon_name": "Addons",
+    "category": "diagnostics",
+    "repos": [
+      "HealsCodes/statustimers"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 15,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Statustimers for Ashita v4",
+    "description_source": "https://github.com/HealsCodes/statustimers",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ambuloot",
+    "addon_name": "Ambuloot",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ase",
+    "addon_name": "Ase",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "assist",
+    "addon_name": "Assist",
+    "category": "automation",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "atreplace",
+    "addon_name": "Atreplace",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "attackid",
+    "addon_name": "Attackid",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "attackwithme",
+    "addon_name": "Attackwithme",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "attend",
+    "addon_name": "Attend",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "augments",
+    "addon_name": "Augments",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autoassist",
+    "addon_name": "Autoassist",
+    "category": "automation",
+    "repos": [
+      "ekrividus/autoAssist"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 13,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "An ffxi windower addon to automatically assist a party member in combat",
+    "description_source": "https://github.com/ekrividus/autoAssist",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autochain",
+    "addon_name": "Autochain",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autodnc",
+    "addon_name": "Autodnc",
+    "category": "automation",
+    "repos": [
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autoinvite",
+    "addon_name": "Autoinvite",
+    "category": "automation",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autopup",
+    "addon_name": "Autopup",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autoraise",
+    "addon_name": "Autoraise",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autoskillchain",
+    "addon_name": "Autoskillchain",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autounm",
+    "addon_name": "Autounm",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autovw",
+    "addon_name": "Autovw",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autowatch",
+    "addon_name": "Autowatch",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "barfiller",
+    "addon_name": "Barfiller",
+    "category": "ui_gear",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "bars",
+    "addon_name": "Bars",
+    "category": "ui_gear",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "battleplan",
+    "addon_name": "Battleplan",
+    "category": "automation",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "blist",
+    "addon_name": "Blist",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "bluspells",
+    "addon_name": "Bluspells",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "broseem",
+    "addon_name": "Broseem",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "bursting",
+    "addon_name": "Bursting",
+    "category": "general_qol",
+    "repos": [
+      "ValokAsura/WindowerAddons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 14,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
     "description_confidence": "low"
+  },
+  {
+    "addon_key": "callouts",
+    "addon_name": "Callouts",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "canteen",
+    "addon_name": "Canteen",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "capetrader",
+    "addon_name": "Capetrader",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "charmed",
+    "addon_name": "Charmed",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chars",
+    "addon_name": "Chars",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatfix",
+    "addon_name": "Chatfix",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatlink",
+    "addon_name": "Chatlink",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatty",
+    "addon_name": "Chatty",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "checkparam",
+    "addon_name": "Checkparam",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chococard",
+    "addon_name": "Chococard",
+    "category": "general_qol",
+    "repos": [
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "clevel",
+    "addon_name": "Clevel",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "closetcleaner2",
+    "addon_name": "ClosetLeaner2",
+    "category": "economy_inventory",
+    "repos": [
+      "Gol-exe/closetCleaner2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "description_source": "https://github.com/Gol-exe/closetCleaner2",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "collector",
+    "addon_name": "Collector",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "colure",
+    "addon_name": "Colure",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "crb_addon",
+    "addon_name": "Crb Addon",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "crystaltrader",
+    "addon_name": "Crystaltrader",
+    "category": "economy_inventory",
+    "repos": [
+      "ValokAsura/WindowerAddons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 14,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "cureplease_addon",
+    "addon_name": "Cureplease Addon",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "currencies",
+    "addon_name": "Currencies",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "debuff-tracker",
+    "addon_name": "Debuff Tracker",
+    "category": "automation",
+    "repos": [
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "digskill",
+    "addon_name": "Digskill",
+    "category": "general_qol",
+    "repos": [
+      "Phayde/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "A collection of addons for FFXI Windower",
+    "description_source": "https://github.com/Phayde/Windower-addons",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "distanceplus",
+    "addon_name": "Distanceplus",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dramagen",
+    "addon_name": "Dramagen",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "drop",
+    "addon_name": "Drop",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dxui",
+    "addon_name": "Dxui",
+    "category": "ui_gear",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "emotes",
+    "addon_name": "Emotes",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "enemybar",
+    "addon_name": "Enemybar",
+    "category": "ui_gear",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "enemybar2",
+    "addon_name": "Enemybar2",
+    "category": "ui_gear",
+    "repos": [
+      "AkadenTK/enemybar2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 19,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
+    "description_source": "https://github.com/AkadenTK/enemybar2",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "eradebuffed",
+    "addon_name": "Eradebuffed",
+    "category": "combat_automation",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "eradistanceplus",
+    "addon_name": "Eradistanceplus",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "erainfobar",
+    "addon_name": "Erainfobar",
+    "category": "ui_gear",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "erajobchange",
+    "addon_name": "Erajobchange",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "eramobdrops",
+    "addon_name": "Eramobdrops",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "eramoblevel",
+    "addon_name": "Eramoblevel",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "erapointwatch",
+    "addon_name": "Erapointwatch",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "erascoreboard",
+    "addon_name": "Erascoreboard",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "eschachest",
+    "addon_name": "Eschachest",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "exorcist",
+    "addon_name": "Exorcist",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "export_items",
+    "addon_name": "Export Items",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fancytrusts",
+    "addon_name": "AncyRusts",
+    "category": "combat_automation",
+    "repos": [
+      "ariel-logos/FancyTrusts"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 5,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "A fancy UI to manage trusts",
+    "description_source": "https://github.com/ariel-logos/FancyTrusts",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "fastfollow",
+    "addon_name": "Fastfollow",
+    "category": "general_qol",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fasttarget",
+    "addon_name": "AstArget",
+    "category": "ui_gear",
+    "repos": [
+      "LordAttilas/FastTarget"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Windower 4 addon for FFXI that allow quicker target change",
+    "description_source": "https://github.com/LordAttilas/FastTarget",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "ffxi-zonename",
+    "addon_name": "FFXI Zonename",
+    "category": "travel_navigation",
+    "repos": [
+      "onimitch/ffxi-zonename"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 4,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.",
+    "description_source": "https://github.com/onimitch/ffxi-zonename",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ffxicaddieprovider",
+    "addon_name": "FFXIcaddieprovider",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ffxikeys",
+    "addon_name": "FFXIkeys",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "finalalert",
+    "addon_name": "Finalalert",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "followme",
+    "addon_name": "Followme",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "gaolplan",
+    "addon_name": "Gaolplan",
+    "category": "automation",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "gilbox",
+    "addon_name": "Gilbox",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "giltracker",
+    "addon_name": "Giltracker",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "gmtools",
+    "addon_name": "Gmtools",
+    "category": "automation",
+    "repos": [
+      "SQLCommit/GMTools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 2,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - LSB GM Command Helper",
+    "description_source": "https://github.com/SQLCommit/GMTools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "helper",
+    "addon_name": "Helper",
+    "category": "automation",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "highlight",
+    "addon_name": "Highlight",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "impalert",
+    "addon_name": "Impalert",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "imrecast",
+    "addon_name": "Imrecast",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "indinope",
+    "addon_name": "Indinope",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "inforeplacer",
+    "addon_name": "Inforeplacer",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "informer",
+    "addon_name": "Informer",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "jingle",
+    "addon_name": "Jingle",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "jobchange",
+    "addon_name": "Jobchange",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "jobinit",
+    "addon_name": "Jobinit",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "kaomoji",
+    "addon_name": "Kaomoji",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "lazy",
+    "addon_name": "Lazy",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "leaderboard",
+    "addon_name": "Leaderboard",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "llmchat",
+    "addon_name": "Llmchat",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "locke",
+    "addon_name": "Locke",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "lockpick",
+    "addon_name": "Lockpick",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "loggers",
+    "addon_name": "Loggers",
+    "category": "diagnostics",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "lootscope",
+    "addon_name": "Lootscope",
+    "category": "economy_inventory",
+    "repos": [
+      "SQLCommit/LootScope"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 2,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - Loot Drop Tracker",
+    "description_source": "https://github.com/SQLCommit/LootScope",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "luaparser",
+    "addon_name": "LuaArser",
+    "category": "diagnostics",
+    "repos": [
+      "Gol-exe/closetCleaner2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "description_source": "https://github.com/Gol-exe/closetCleaner2",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "maga",
+    "addon_name": "Maga",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "masstrade",
+    "addon_name": "Masstrade",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "memscope",
+    "addon_name": "Memscope",
+    "category": "diagnostics",
+    "repos": [
+      "SQLCommit/MemScope"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 2,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage",
+    "description_source": "https://github.com/SQLCommit/MemScope",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "menufix",
+    "addon_name": "Menufix",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "menus",
+    "addon_name": "Menus",
+    "category": "automation",
+    "repos": [
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "minimap-helper",
+    "addon_name": "Minimap Helper",
+    "category": "automation",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "mousehalo",
+    "addon_name": "Mousehalo",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "moveitems",
+    "addon_name": "Moveitems",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "myhome",
+    "addon_name": "Myhome",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "myomen",
+    "addon_name": "Myomen",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "nnitimer",
+    "addon_name": "Nnitimer",
+    "category": "diagnostics",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "noknock",
+    "addon_name": "Noknock",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "nostrum",
+    "addon_name": "Nostrum",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ohshi",
+    "addon_name": "Ohshi",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ondemand",
+    "addon_name": "Ondemand",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "oneoffs",
+    "addon_name": "Oneoffs",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "packetviewerlogviewer",
+    "addon_name": "Packetviewerlogviewer",
+    "category": "diagnostics",
+    "repos": [
+      "ZeromusXYZ/PacketViewerLogViewer"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
+    "description_source": "https://github.com/ZeromusXYZ/PacketViewerLogViewer",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "partypets",
+    "addon_name": "Partypets",
+    "category": "ui_gear",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "pet_fix",
+    "addon_name": "Pet Fix",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "petparty",
+    "addon_name": "Petparty",
+    "category": "ui_gear",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "plasmon",
+    "addon_name": "Plasmon",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "plugin_manager",
+    "addon_name": "Plugin Manager",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "position_manager",
+    "addon_name": "Position Manager",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "positions",
+    "addon_name": "Positions",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "questlog",
+    "addon_name": "Questlog",
+    "category": "general_qol",
+    "repos": [
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 79,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "quicktrade_2",
+    "addon_name": "Quicktrade 2",
+    "category": "ui_gear",
+    "repos": [
+      "ValokAsura/WindowerAddons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 14,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "rcheck",
+    "addon_name": "Rcheck",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "readable",
+    "addon_name": "Readable",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "reive",
+    "addon_name": "Reive",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "relicge",
+    "addon_name": "Relicge",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "repeater",
+    "addon_name": "Repeater",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "repl",
+    "addon_name": "Repl",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "rhombus",
+    "addon_name": "Rhombus",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "roe",
+    "addon_name": "Roe",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "rollbot",
+    "addon_name": "Rollbot",
+    "category": "automation",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "rolldistance",
+    "addon_name": "Rolldistance",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "rtfm",
+    "addon_name": "Rtfm",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "runicportal",
+    "addon_name": "Runicportal",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "safeoboro",
+    "addon_name": "Safeoboro",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "salvage2",
+    "addon_name": "Salvage2",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "satacast",
+    "addon_name": "Satacast",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "scanzone",
+    "addon_name": "Scanzone",
+    "category": "travel_navigation",
+    "repos": [
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "schskillchain",
+    "addon_name": "Schskillchain",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "scriptedextender",
+    "addon_name": "Scriptedextender",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "sendalltarget",
+    "addon_name": "Sendalltarget",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "setbgm",
+    "addon_name": "Setbgm",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "settarget",
+    "addon_name": "Settarget",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "silttracker",
+    "addon_name": "Silttracker",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "simpleassist",
+    "addon_name": "Simpleassist",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "sirpopalot",
+    "addon_name": "Sirpopalot",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "skilluptracker",
+    "addon_name": "Skilluptracker",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "smeagol",
+    "addon_name": "Smeagol",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "special",
+    "addon_name": "Special",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "spellspammer",
+    "addon_name": "Spellspammer",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "stars",
+    "addon_name": "Stars",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "stna",
+    "addon_name": "Stna",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "stopwatch",
+    "addon_name": "Stopwatch",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "strathelper",
+    "addon_name": "Strathelper",
+    "category": "automation",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "strats",
+    "addon_name": "Strats",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "sweeper",
+    "addon_name": "Sweeper",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "synergy",
+    "addon_name": "Synergy",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "taps",
+    "addon_name": "Taps",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "targeter",
+    "addon_name": "Targeter",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "targetinfo",
+    "addon_name": "Targetinfo",
+    "category": "combat_automation",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "targetinfoex",
+    "addon_name": "Targetinfoex",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "targetplus",
+    "addon_name": "Targetplus",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "taskbar",
+    "addon_name": "Taskbar",
+    "category": "ui_gear",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tellapart",
+    "addon_name": "Tellapart",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tellfix",
+    "addon_name": "Tellfix",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "text",
+    "addon_name": "Text",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "thfknife",
+    "addon_name": "Thfknife",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tiptoes",
+    "addon_name": "Tiptoes",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tonic",
+    "addon_name": "Tonic",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tourist",
+    "addon_name": "Tourist",
+    "category": "travel_navigation",
+    "repos": [
+      "Bryenne-Sylph/tourist"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
+    "description_source": "https://github.com/Bryenne-Sylph/tourist",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tpsreport",
+    "addon_name": "Tpsreport",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trader",
+    "addon_name": "Trader",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "translate",
+    "addon_name": "Translate",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trashit",
+    "addon_name": "Trashit",
+    "category": "general_qol",
+    "repos": [
+      "Phayde/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "A collection of addons for FFXI Windower",
+    "description_source": "https://github.com/Phayde/Windower-addons",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "trials",
+    "addon_name": "Trials",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trialtracker",
+    "addon_name": "Trialtracker",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "triggers",
+    "addon_name": "Triggers",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "truesight",
+    "addon_name": "Truesight",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trust",
+    "addon_name": "Trust",
+    "category": "automation",
+    "repos": [
+      "cyritegamestudios/trust"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 49,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Windower 4 addon for FFXI to automate your character in battle.",
+    "description_source": "https://github.com/cyritegamestudios/trust",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "turnaround",
+    "addon_name": "Turnaround",
+    "category": "automation",
+    "repos": [
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 99,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ui",
+    "addon_name": "Ui",
+    "category": "ui_gear",
+    "repos": [
+      "AliekberFFXI/xivcrossbar"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
+    "description_source": "https://github.com/AliekberFFXI/xivcrossbar",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "useall",
+    "addon_name": "Useall",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "valkyrie",
+    "addon_name": "Valkyrie",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanaclock",
+    "addon_name": "Vanaclock",
+    "category": "travel_navigation",
+    "repos": [
+      "BagTown/vanaclock"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "description_source": "https://github.com/BagTown/vanaclock",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "vanafacts",
+    "addon_name": "Vanafacts",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanapad",
+    "addon_name": "Vanapad",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanatime",
+    "addon_name": "Vanatime",
+    "category": "general_qol",
+    "repos": [
+      "BagTown/vanaclock"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "description_source": "https://github.com/BagTown/vanaclock",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "vanity",
+    "addon_name": "Vanity",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "visiblefavor",
+    "addon_name": "Visiblefavor",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "voidwalker",
+    "addon_name": "Voidwalker",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "voidwatch",
+    "addon_name": "Voidwatch",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vwpop",
+    "addon_name": "Vwpop",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "warpmenu",
+    "addon_name": "Warpmenu",
+    "category": "travel_navigation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "waveback",
+    "addon_name": "Waveback",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "weathermon",
+    "addon_name": "Weathermon",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "weeklier",
+    "addon_name": "Weeklier",
+    "category": "diagnostics",
+    "repos": [
+      "patheed-ffxi/weeklier"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.",
+    "description_source": "https://github.com/patheed-ffxi/weeklier",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "wheel",
+    "addon_name": "Wheel",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "where",
+    "addon_name": "Where",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "widescantool",
+    "addon_name": "Widescantool",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "witnessprotection",
+    "addon_name": "Witnessprotection",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "woehelper",
+    "addon_name": "Woehelper",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xichecklist",
+    "addon_name": "XIchecklist",
+    "category": "travel_navigation",
+    "repos": [
+      "HiPotionQ8/XIchecklist"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 4,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
+    "description_source": "https://github.com/HiPotionQ8/XIchecklist",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xipivot",
+    "addon_name": "XIpivot",
+    "category": "general_qol",
+    "repos": [
+      "HealsCodes/XIPivot"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 61,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
+    "description_source": "https://github.com/HealsCodes/XIPivot",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xitools",
+    "addon_name": "XItools",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xivcrossbar",
+    "addon_name": "XIvcrossbar",
+    "category": "ui_gear",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xivhotbar",
+    "addon_name": "XIvhotbar",
+    "category": "ui_gear",
+    "repos": [
+      "Akirane/XIVHotbar"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "",
+    "description_source": "",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "xivhotbar2",
+    "addon_name": "XIvhotbar2",
+    "category": "ui_gear",
+    "repos": [
+      "Technyze/XIVHotbar2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 13,
+    "freshness_max": 2,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "xivparty",
+    "addon_name": "XIvparty",
+    "category": "ui_gear",
+    "repos": [
+      "Tylas11/XivParty"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 47,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "A party list addon for Windower 4.",
+    "description_source": "https://github.com/Tylas11/XivParty",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "yush",
+    "addon_name": "Yush",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "zenimonsnap",
+    "addon_name": "Zenimonsnap",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "znmtracker",
+    "addon_name": "Znmtracker",
+    "category": "general_qol",
+    "repos": [
+      "iLVL-Key/FFXI"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 22,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "zonelines",
+    "addon_name": "Zonelines",
+    "category": "travel_navigation",
+    "repos": [
+      "SQLCommit/ZoneLines"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 2,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - Zone Line Visualizer",
+    "description_source": "https://github.com/SQLCommit/ZoneLines",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "zonename",
+    "addon_name": "Zonename",
+    "category": "travel_navigation",
+    "repos": [
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
   }
 ]

--- a/ffxi_addons_index_raw.json
+++ b/ffxi_addons_index_raw.json
@@ -1,40 +1,149 @@
 [
   {
-    "repo": "ProjectTako/ffxi-addons",
-    "stars": 99,
-    "pushed_at": "2022-11-09T19:45:51Z",
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "repo": "AkadenTK/enemybar2",
+    "stars": 19,
+    "pushed_at": "2021-01-30T19:48:45Z",
+    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
     "addon_dirs": [
-      "allseeingeye",
-      "debuff-tracker",
-      "equipviewer",
-      "fastcs",
-      "menus",
-      "partybuffs",
-      "react",
-      "scanzone",
-      "turnaround"
+      "icons"
     ]
   },
   {
-    "repo": "Ivaar/Windower-addons",
-    "stars": 79,
-    "pushed_at": "2023-09-12T03:56:46Z",
-    "description": "FFXI Windower addons",
+    "repo": "AkadenTK/superwarp",
+    "stars": 55,
+    "pushed_at": "2026-03-18T13:55:18Z",
+    "description": "Addon for Windower 4 for FFXI that allows text commands to utilize homepoint, waypoint and survival guide teleport npcs",
     "addon_dirs": [
-      "AuctionHelper",
-      "AutoCOR",
-      "AutoDNC",
-      "AutoGEO",
-      "ChatMan",
-      "PorterPacker",
-      "QuestLog",
-      "SellNPC",
-      "Singer",
-      "Trade",
-      "TradeNPC",
-      "chococard",
-      "htmb"
+      "map"
+    ]
+  },
+  {
+    "repo": "Akirane/XIVHotbar",
+    "stars": 18,
+    "pushed_at": "2020-12-26T23:55:51Z",
+    "description": "",
+    "addon_dirs": [
+      "data",
+      "priv_res",
+      "themes"
+    ]
+  },
+  {
+    "repo": "AliekberFFXI/xivcrossbar",
+    "stars": 17,
+    "pushed_at": "2022-09-15T22:03:23Z",
+    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
+    "addon_dirs": [
+      "libs",
+      "themes",
+      "ui"
+    ]
+  },
+  {
+    "repo": "ariel-logos/FancyTrusts",
+    "stars": 5,
+    "pushed_at": "2026-04-09T10:34:01Z",
+    "description": "A fancy UI to manage trusts",
+    "addon_dirs": [
+      "FancyTrusts"
+    ]
+  },
+  {
+    "repo": "BagTown/vanaclock",
+    "stars": 3,
+    "pushed_at": "2026-03-30T01:43:40Z",
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "addon_dirs": [
+      "vanaclock",
+      "vanatime"
+    ]
+  },
+  {
+    "repo": "Bryenne-Sylph/tourist",
+    "stars": 3,
+    "pushed_at": "2026-03-15T20:10:54Z",
+    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
+    "addon_dirs": [
+      "tourist"
+    ]
+  },
+  {
+    "repo": "cyritegamestudios/trust",
+    "stars": 49,
+    "pushed_at": "2026-04-23T04:17:39Z",
+    "description": "Windower 4 addon for FFXI to automate your character in battle.",
+    "addon_dirs": [
+      "trust"
+    ]
+  },
+  {
+    "repo": "DiscipleOfEris/Windower4Addons",
+    "stars": 12,
+    "pushed_at": "2024-02-18T18:22:59Z",
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "addon_dirs": [
+      "EraDebuffed",
+      "EraDistancePlus",
+      "EraInfoBar",
+      "EraJobChange",
+      "EraMobDrops",
+      "EraMobLevel",
+      "EraPointWatch",
+      "EraScoreboard",
+      "FastFollow",
+      "SendTarget",
+      "assist"
+    ]
+  },
+  {
+    "repo": "ekrividus/autoAssist",
+    "stars": 13,
+    "pushed_at": "2022-11-26T19:34:33Z",
+    "description": "An ffxi windower addon to automatically assist a party member in combat",
+    "addon_dirs": []
+  },
+  {
+    "repo": "flippant/parse",
+    "stars": 15,
+    "pushed_at": "2023-08-12T01:51:20Z",
+    "description": "FFXI Parser Addon for Windower",
+    "addon_dirs": []
+  },
+  {
+    "repo": "Gol-exe/closetCleaner2",
+    "stars": 0,
+    "pushed_at": "2026-04-23T20:03:49Z",
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "addon_dirs": [
+      "closetCleaner2",
+      "luaParser"
+    ]
+  },
+  {
+    "repo": "HealsCodes/statustimers",
+    "stars": 15,
+    "pushed_at": "2026-03-01T14:25:55Z",
+    "description": "Statustimers for Ashita v4",
+    "addon_dirs": [
+      "addons"
+    ]
+  },
+  {
+    "repo": "HealsCodes/XIPivot",
+    "stars": 61,
+    "pushed_at": "2026-01-31T13:44:31Z",
+    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
+    "addon_dirs": [
+      "XIPivot"
+    ]
+  },
+  {
+    "repo": "HiPotionQ8/XIchecklist",
+    "stars": 4,
+    "pushed_at": "2026-04-23T09:57:29Z",
+    "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
+    "addon_dirs": [
+      "XIchecklist"
     ]
   },
   {
@@ -186,21 +295,30 @@
     ]
   },
   {
-    "repo": "HealsCodes/XIPivot",
-    "stars": 61,
-    "pushed_at": "2026-01-31T13:44:31Z",
-    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
+    "repo": "iLVL-Key/FFXI",
+    "stars": 22,
+    "pushed_at": "2026-04-22T15:03:22Z",
+    "description": "Various FFXI projects",
     "addon_dirs": [
-      "XIPivot"
-    ]
-  },
-  {
-    "repo": "AkadenTK/superwarp",
-    "stars": 55,
-    "pushed_at": "2026-03-18T13:55:18Z",
-    "description": "Addon for Windower 4 for FFXI that allows text commands to utilize homepoint, waypoint and survival guide teleport npcs",
-    "addon_dirs": [
-      "map"
+      "Attend",
+      "Bars",
+      "BattlePlan",
+      "Callouts",
+      "Exorcist",
+      "GaolPlan",
+      "Helper",
+      "Informer",
+      "Jingle",
+      "LLMChat",
+      "Leaderboard",
+      "ReadyCheck",
+      "Sweeper",
+      "TaskBar",
+      "VanaFacts",
+      "VanaPad",
+      "Vanity",
+      "ZNMTracker",
+      "emotes"
     ]
   },
   {
@@ -211,22 +329,24 @@
     "addon_dirs": []
   },
   {
-    "repo": "cyritegamestudios/trust",
-    "stars": 49,
-    "pushed_at": "2026-04-23T04:17:39Z",
-    "description": "Windower 4 addon for FFXI to automate your character in battle.",
+    "repo": "Ivaar/Windower-addons",
+    "stars": 79,
+    "pushed_at": "2023-09-12T03:56:46Z",
+    "description": "FFXI Windower addons",
     "addon_dirs": [
-      "trust"
-    ]
-  },
-  {
-    "repo": "Tylas11/XivParty",
-    "stars": 47,
-    "pushed_at": "2026-02-26T20:01:30Z",
-    "description": "A party list addon for Windower 4.",
-    "addon_dirs": [
-      "assets",
-      "layouts"
+      "AuctionHelper",
+      "AutoCOR",
+      "AutoDNC",
+      "AutoGEO",
+      "ChatMan",
+      "PorterPacker",
+      "QuestLog",
+      "SellNPC",
+      "Singer",
+      "Trade",
+      "TradeNPC",
+      "chococard",
+      "htmb"
     ]
   },
   {
@@ -271,31 +391,6 @@
     ]
   },
   {
-    "repo": "mousseng/xitools",
-    "stars": 29,
-    "pushed_at": "2026-03-10T17:38:26Z",
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "addon_dirs": [
-      "bluspells",
-      "chatty",
-      "colure",
-      "dxui",
-      "imrecast",
-      "libs",
-      "loggers",
-      "minimap-helper",
-      "omen",
-      "rcheck",
-      "relicge",
-      "repl",
-      "skillchain",
-      "strats",
-      "trials",
-      "wheel",
-      "xitools"
-    ]
-  },
-  {
     "repo": "lorand-ffxi/HealBot",
     "stars": 28,
     "pushed_at": "2018-05-22T20:21:49Z",
@@ -305,50 +400,21 @@
     ]
   },
   {
-    "repo": "iLVL-Key/FFXI",
-    "stars": 22,
-    "pushed_at": "2026-04-22T15:03:22Z",
-    "description": "Various FFXI projects",
+    "repo": "LordAttilas/FastTarget",
+    "stars": 0,
+    "pushed_at": "2026-04-18T01:11:58Z",
+    "description": "Windower 4 addon for FFXI that allow quicker target change",
     "addon_dirs": [
-      "Attend",
-      "Bars",
-      "BattlePlan",
-      "Callouts",
-      "Exorcist",
-      "GaolPlan",
-      "Helper",
-      "Informer",
-      "Jingle",
-      "LLMChat",
-      "Leaderboard",
-      "ReadyCheck",
-      "Sweeper",
-      "TaskBar",
-      "VanaFacts",
-      "VanaPad",
-      "Vanity",
-      "ZNMTracker",
-      "emotes"
+      "FastTarget"
     ]
   },
   {
-    "repo": "AkadenTK/enemybar2",
-    "stars": 19,
-    "pushed_at": "2021-01-30T19:48:45Z",
-    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
+    "repo": "Lydya-nick77/readycheck",
+    "stars": 0,
+    "pushed_at": "2026-04-12T14:11:47Z",
+    "description": "FFXI addon to execute a WoW Style Readycheck with the party/alliance",
     "addon_dirs": [
-      "icons"
-    ]
-  },
-  {
-    "repo": "Akirane/XIVHotbar",
-    "stars": 18,
-    "pushed_at": "2020-12-26T23:55:51Z",
-    "description": "",
-    "addon_dirs": [
-      "data",
-      "priv_res",
-      "themes"
+      "readycheck"
     ]
   },
   {
@@ -437,14 +503,28 @@
     ]
   },
   {
-    "repo": "AliekberFFXI/xivcrossbar",
-    "stars": 17,
-    "pushed_at": "2022-09-15T22:03:23Z",
-    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
+    "repo": "mousseng/xitools",
+    "stars": 29,
+    "pushed_at": "2026-03-10T17:38:26Z",
+    "description": "Some addons and plugins for FFXI (Ashita)",
     "addon_dirs": [
+      "bluspells",
+      "chatty",
+      "colure",
+      "dxui",
+      "imrecast",
       "libs",
-      "themes",
-      "ui"
+      "loggers",
+      "minimap-helper",
+      "omen",
+      "rcheck",
+      "relicge",
+      "repl",
+      "skillchain",
+      "strats",
+      "trials",
+      "wheel",
+      "xitools"
     ]
   },
   {
@@ -533,95 +613,6 @@
     ]
   },
   {
-    "repo": "ZeromusXYZ/PacketViewerLogViewer",
-    "stars": 17,
-    "pushed_at": "2023-05-18T06:00:22Z",
-    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
-    "addon_dirs": [
-      "Properties",
-      "Res",
-      "data",
-      "forms",
-      "helpers",
-      "redist"
-    ]
-  },
-  {
-    "repo": "flippant/parse",
-    "stars": 15,
-    "pushed_at": "2023-08-12T01:51:20Z",
-    "description": "FFXI Parser Addon for Windower",
-    "addon_dirs": []
-  },
-  {
-    "repo": "HealsCodes/statustimers",
-    "stars": 15,
-    "pushed_at": "2026-03-01T14:25:55Z",
-    "description": "Statustimers for Ashita v4",
-    "addon_dirs": [
-      "addons"
-    ]
-  },
-  {
-    "repo": "ValokAsura/WindowerAddons",
-    "stars": 14,
-    "pushed_at": "2023-02-04T00:29:37Z",
-    "description": "",
-    "addon_dirs": [
-      "Bursting",
-      "CrystalTrader",
-      "MagicAssistant",
-      "QuickTrade 2",
-      "QuickTrade"
-    ]
-  },
-  {
-    "repo": "ekrividus/autoAssist",
-    "stars": 13,
-    "pushed_at": "2022-11-26T19:34:33Z",
-    "description": "An ffxi windower addon to automatically assist a party member in combat",
-    "addon_dirs": []
-  },
-  {
-    "repo": "Technyze/XIVHotbar2",
-    "stars": 13,
-    "pushed_at": "2023-03-12T03:29:46Z",
-    "description": "",
-    "addon_dirs": [
-      "data",
-      "priv_res",
-      "themes"
-    ]
-  },
-  {
-    "repo": "DiscipleOfEris/Windower4Addons",
-    "stars": 12,
-    "pushed_at": "2024-02-18T18:22:59Z",
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "addon_dirs": [
-      "EraDebuffed",
-      "EraDistancePlus",
-      "EraInfoBar",
-      "EraJobChange",
-      "EraMobDrops",
-      "EraMobLevel",
-      "EraPointWatch",
-      "EraScoreboard",
-      "FastFollow",
-      "SendTarget",
-      "assist"
-    ]
-  },
-  {
-    "repo": "HiPotionQ8/XIchecklist",
-    "stars": 4,
-    "pushed_at": "2026-04-23T09:57:29Z",
-    "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
-    "addon_dirs": [
-      "XIchecklist"
-    ]
-  },
-  {
     "repo": "onimitch/ffxi-zonename",
     "stars": 4,
     "pushed_at": "2026-04-05T14:44:54Z",
@@ -629,12 +620,40 @@
     "addon_dirs": []
   },
   {
-    "repo": "Bryenne-Sylph/tourist",
-    "stars": 3,
-    "pushed_at": "2026-03-15T20:10:54Z",
-    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
+    "repo": "patheed-ffxi/weeklier",
+    "stars": 0,
+    "pushed_at": "2026-04-18T13:06:18Z",
+    "description": "An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.",
     "addon_dirs": [
-      "tourist"
+      "weeklier"
+    ]
+  },
+  {
+    "repo": "Phayde/Windower-addons",
+    "stars": 1,
+    "pushed_at": "2026-04-16T02:53:51Z",
+    "description": "A collection of addons for FFXI Windower",
+    "addon_dirs": [
+      "digskill",
+      "smarttarget",
+      "trashit"
+    ]
+  },
+  {
+    "repo": "ProjectTako/ffxi-addons",
+    "stars": 99,
+    "pushed_at": "2022-11-09T19:45:51Z",
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "addon_dirs": [
+      "allseeingeye",
+      "debuff-tracker",
+      "equipviewer",
+      "fastcs",
+      "menus",
+      "partybuffs",
+      "react",
+      "scanzone",
+      "turnaround"
     ]
   },
   {
@@ -666,5 +685,53 @@
     "pushed_at": "2026-03-20T01:38:26Z",
     "description": "FFXI - Ashita v4.3 Addon - Zone Line Visualizer",
     "addon_dirs": []
+  },
+  {
+    "repo": "Technyze/XIVHotbar2",
+    "stars": 13,
+    "pushed_at": "2023-03-12T03:29:46Z",
+    "description": "",
+    "addon_dirs": [
+      "data",
+      "priv_res",
+      "themes"
+    ]
+  },
+  {
+    "repo": "Tylas11/XivParty",
+    "stars": 47,
+    "pushed_at": "2026-02-26T20:01:30Z",
+    "description": "A party list addon for Windower 4.",
+    "addon_dirs": [
+      "assets",
+      "layouts"
+    ]
+  },
+  {
+    "repo": "ValokAsura/WindowerAddons",
+    "stars": 14,
+    "pushed_at": "2023-02-04T00:29:37Z",
+    "description": "",
+    "addon_dirs": [
+      "Bursting",
+      "CrystalTrader",
+      "MagicAssistant",
+      "QuickTrade 2",
+      "QuickTrade"
+    ]
+  },
+  {
+    "repo": "ZeromusXYZ/PacketViewerLogViewer",
+    "stars": 17,
+    "pushed_at": "2023-05-18T06:00:22Z",
+    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
+    "addon_dirs": [
+      "Properties",
+      "Res",
+      "data",
+      "forms",
+      "helpers",
+      "redist"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
4h repository/addon sync for catalog artifacts only (raw index + normalized JSON/CSV + sync doc).

### Newly added repos
- Phayde/Windower-addons
- Lydya-nick77/readycheck
- BagTown/vanaclock
- LordAttilas/FastTarget
- ariel-logos/FancyTrusts
- Gol-exe/closetCleaner2
- patheed-ffxi/weeklier

### Newly added addon entries
- digskill
- smarttarget
- trashit
- readycheck
- vanaclock
- vanatime
- fasttarget
- fancytrusts
- closetcleaner2
- luaparser
- weeklier

### Removed/stale entries
- Removed repos: none
- Removed addon entries: none

## Confidence notes
- **High confidence**: added repo existence + metadata (stars/pushed_at/description) from GitHub API.
- **Medium confidence**: collection-style directory extraction in `Phayde/Windower-addons`.
- **Lower confidence**: a few Lua-derived names may be helper modules rather than standalone addons (`vanatime`, `luaparser`).

## Validation
- `python3 -m json.tool ffxi_addons_index_raw.json`
- `python3 -m json.tool ffxi-addon-catalog-normalized.json`
- CSV row count matches normalized JSON count.

## Scope check
Changes are intentionally limited to:
- `ffxi_addons_index_raw.json`
- `ffxi-addon-catalog-normalized.json`
- `ffxi-addon-catalog-normalized.csv`
- `docs/sync-2026-04-24-0000.md`

