### PR TITLE
feat(TravelRouter): add explain command for candidate score transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ See specs:
 - Load: `//lua load TravelRouter`
 - Verify routes: `//troute list`
 - Verify planner: `//troute plan jeuno`
+- Verify route scoring detail: `//troute explain jeuno`
 - Verify execution: `//troute run jeuno`
 - (Optional) Configure unlock tokens: `//troute unlock add hp|sg|warp`
 - (Optional) Add typo-friendly shortcuts: `//troute alias add <alias> <destination>`

--- a/addons/TravelRouter/README.md
+++ b/addons/TravelRouter/README.md
@@ -17,6 +17,7 @@ Content-aware travel routing addon for Windower.
 ## Commands
 - `//troute list` — list known destinations
 - `//troute plan <destination>` — print best route + scoring rationale
+- `//troute explain <destination>` — show ranked candidate scores and selection reasons
 - `//troute run <destination>` — execute selected route
 - `//troute add <destination> <step1> ; <step2> ; ...` — persist user route override
 - `//troute reset <destination>` — remove user override for destination

--- a/addons/TravelRouter/travelrouter.lua
+++ b/addons/TravelRouter/travelrouter.lua
@@ -194,6 +194,41 @@ local function print_plan(dest)
     return true, plan
 end
 
+local function explain_plan(dest)
+    local key = normalize(dest)
+    local candidates = route_candidates(key)
+    if not candidates then
+        msg(('No route for "%s". Use //troute list or //troute add ...'):format(dest or ''))
+        return false
+    end
+
+    local ranked = {}
+    for idx, c in ipairs(candidates) do
+        local score, reasons = score_candidate(c)
+        ranked[#ranked+1] = { idx = idx, candidate = c, score = score, reasons = reasons }
+    end
+
+    table.sort(ranked, function(a, b)
+        if a.score == b.score then
+            return (a.candidate.name or ('option-' .. a.idx)) < (b.candidate.name or ('option-' .. b.idx))
+        end
+        return a.score > b.score
+    end)
+
+    msg(('Candidate scoring for "%s" (%d option%s):'):format(key, #ranked, (#ranked == 1 and '' or 's')))
+    for i, row in ipairs(ranked) do
+        local c = row.candidate
+        local req = (c.requires and #c.requires > 0) and table.concat(c.requires, ', ') or 'none'
+        local marker = (i == 1) and '*' or '-'
+        msg(('  %s %d) %s | score=%d | requires=%s'):format(marker, i, c.name or ('option-' .. row.idx), row.score, req))
+        if row.reasons and #row.reasons > 0 then
+            msg('      rationale: ' .. table.concat(row.reasons, ', '))
+        end
+    end
+    msg('  * top-ranked option is used by //troute plan and //troute run')
+    return true
+end
+
 local function execute_step(step)
     if step:sub(1,4) == 'say:' then msg(step:sub(5)); return end
     if step:sub(1,5) == 'wait:' then
@@ -371,11 +406,12 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1])
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: list | plan <dest> | run <dest> | add <dest> <s1>;... | reset <dest> | alias list|add|remove ... | unlock list|add|remove <k> | save')
+        msg('Commands: list | plan <dest> | explain <dest> | run <dest> | add <dest> <s1>;... | reset <dest> | alias list|add|remove ... | unlock list|add|remove <k> | save')
         return
     end
     if cmd == 'list' then list_destinations(); return end
     if cmd == 'plan' then print_plan(join(args, ' ', 2)); return end
+    if cmd == 'explain' then explain_plan(join(args, ' ', 2)); return end
     if cmd == 'run' then run_plan(join(args, ' ', 2)); return end
     if cmd == 'add' then add_route(args[2], join(args, ' ', 3)); return end
     if cmd == 'reset' then reset_route(join(args, ' ', 2)); return end

--- a/tests/test_travelrouter.lua
+++ b/tests/test_travelrouter.lua
@@ -37,6 +37,17 @@ log = mock.get_chat_log()
 check('plan produces output', #log > 0)
 check('plan mentions jeuno', log[1] and log[1].text:find('jeuno') ~= nil)
 
+-- test explain with known destination
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'explain', 'jeuno')
+log = mock.get_chat_log()
+check('explain produces output', #log > 1)
+check('explain includes candidate scoring header', log[1] and log[1].text:find('Candidate scoring') ~= nil)
+check('explain includes selected marker note', log[#log] and log[#log].text:find('top%-ranked option') ~= nil)
+
 -- test plan with unknown destination
 mock.reset()
 mock.install()


### PR DESCRIPTION
## Summary
Adds a new `//troute explain <destination>` command that prints ranked route candidates with score details and rationale.

### What changed
- Added `explain_plan()` to TravelRouter to:
  - rank all candidates using existing scoring logic
  - print required unlock tokens per candidate
  - show rationale terms used in score computation
  - mark top-ranked candidate selected by `plan`/`run`
- Updated command help output to include `explain`.
- Added/updated docs:
  - `addons/TravelRouter/README.md` command list
  - root `README.md` production checklist smoke test
- Added test coverage in `tests/test_travelrouter.lua` for `explain` output path.

## Validation
Ran `./scripts/validate.sh`:
- ✅ Catalog JSON validation passed
- ✅ SessionConductor default rules validation passed
- ✅ TravelRouter route file validation passed
- ⚠️ Lua syntax checks skipped (`luac` not available in environment)
- ⚠️ Unit tests skipped (`lua`/`lua5.1` not available in environment)

## Risk / Rollback
### Risk
- Low risk, additive command only.
- Existing `plan`/`run` selection logic unchanged (same scoring function reused).
- Main regression surface is chat output formatting and command dispatch table.

### Rollback
- Revert commit `673a77b` to remove `explain` command and docs/tests in one step.
