### PR TITLE
chore(sync): 4h catalog refresh (2026-04-24 0400 UTC)

### DIFF
--- a/docs/sync-2026-04-24-0400.md
+++ b/docs/sync-2026-04-24-0400.md
@@ -1,0 +1,61 @@
+# 4h Sync Report — 2026-04-24 04:00 UTC
+
+## Scope
+Catalog/index/docs maintenance only:
+- `ffxi_addons_index_raw.json`
+- `ffxi-addon-catalog-normalized.json`
+- `ffxi-addon-catalog-normalized.csv`
+- `docs/sync-2026-04-24-0400.md`
+
+## Repository deltas
+### Added repos
+- `Phayde/Windower-addons`
+- `Lydya-nick77/readycheck`
+- `BagTown/vanaclock`
+- `LordAttilas/FastTarget`
+- `ariel-logos/FancyTrusts`
+- `Gol-exe/closetCleaner2`
+- `patheed-ffxi/weeklier`
+- `glitchv0/mogchat`
+- `cybersoulwing/dpsmeter`
+- `cybersoulwing/AutoMining`
+- `Mr-Sithel/packrat`
+
+### Updated repo metadata
+- Refreshed stars / `pushed_at` / descriptions for indexed repositories using GitHub API.
+
+### Removed repos
+- None in this sync.
+
+## Addon deltas (normalized catalog)
+### Newly added addon entries
+- `digskill`
+- `trashit`
+- `vanaclock`
+- `vanatime`
+- `fasttarget`
+- `fancytrusts`
+- `closetcleaner2`
+- `luaparser`
+- `weeklier`
+- `mogchat`
+- `dpsmeter`
+- `automining`
+- `packrat`
+
+### Updated addon mappings
+- `readycheck` now includes `Lydya-nick77/readycheck` as a source repo.
+- `smarttarget` now includes `Phayde/Windower-addons` as a source repo.
+
+### Removed/stale addon entries
+- None removed in this pass.
+
+## Confidence notes
+- **High confidence**: repo existence/metadata (stars, timestamps, descriptions) from GitHub API.
+- **Medium confidence**: addon extraction for multi-addon repositories where directory names map directly to addon names.
+- **Lower confidence**: some single-purpose/smaller repos may include support modules mixed with addon code (e.g., `luaparser` in `closetCleaner2`).
+
+## Validation
+- Validation script passed: `./scripts/validate.sh`
+- JSON artifacts parse cleanly (`python3 -m json.tool`).
+- CSV regenerated from normalized JSON with matching row count.

--- a/ffxi-addon-catalog-normalized.csv
+++ b/ffxi-addon-catalog-normalized.csv
@@ -56,7 +56,7 @@ informer,Informer,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,ht
 jingle,Jingle,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 leaderboard,Leaderboard,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 llmchat,Llmchat,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-readycheck,Readycheck,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+readycheck,Readycheck,general_qol,Lydya-nick77/readycheck;iLVL-Key/FFXI,2,22,1,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 sweeper,Sweeper,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 taskbar,Taskbar,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 vanafacts,Vanafacts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
@@ -153,7 +153,7 @@ sendalltarget,Sendalltarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,F
 settarget,Settarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 simpleassist,Simpleassist,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 sirpopalot,Sirpopalot,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-smarttarget,Smarttarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+smarttarget,Smarttarget,combat_automation,Icydeath/ffxi-addons;Phayde/Windower-addons,2,69,8,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 spellspammer,Spellspammer,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 stars,Stars,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 synergy,Synergy,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
@@ -294,3 +294,16 @@ tparty,Tparty,ui_gear,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addo
 treasury,Treasury,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 zonetimer,Zonetimer,travel_navigation,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 healbot,Healbot,automation,Icydeath/ffxi-addons;Lygre/addons;lorand-ffxi/HealBot;mverteuil/windower4-addons,4,69,1,1.57,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low
+digskill,Digskill,general_qol,Phayde/Windower-addons,1,1,8,4.2,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,medium
+trashit,Trashit,general_qol,Phayde/Windower-addons,1,1,8,4.2,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,medium
+vanaclock,Vanaclock,general_qol,BagTown/vanaclock,1,3,25,4.2,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,medium
+vanatime,Vanatime,general_qol,BagTown/vanaclock,1,3,25,4.2,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,medium
+fasttarget,Fasttarget,general_qol,LordAttilas/FastTarget,1,0,6,4.2,Windower 4 addon for FFXI that allow quicker target change,https://github.com/LordAttilas/FastTarget,medium
+fancytrusts,Fancytrusts,general_qol,ariel-logos/FancyTrusts,1,5,14,4.2,A fancy UI to manage trusts,https://github.com/ariel-logos/FancyTrusts,medium
+closetcleaner2,Closetcleaner2,general_qol,Gol-exe/closetCleaner2,1,0,0,4.2,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,medium
+luaparser,Luaparser,general_qol,Gol-exe/closetCleaner2,1,0,0,4.2,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,medium
+weeklier,Weeklier,general_qol,patheed-ffxi/weeklier,1,0,5,4.2,An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.,https://github.com/patheed-ffxi/weeklier,medium
+mogchat,Mogchat,general_qol,glitchv0/mogchat,1,0,1,4.2,AIM/ICQ style FFXI chat addon,https://github.com/glitchv0/mogchat,medium
+dpsmeter,Dpsmeter,general_qol,cybersoulwing/dpsmeter,1,0,12,4.2,FFXI Windower addon,https://github.com/cybersoulwing/dpsmeter,medium
+automining,Automining,general_qol,cybersoulwing/AutoMining,1,0,14,4.2,FFXI Windower addon,https://github.com/cybersoulwing/AutoMining,medium
+packrat,Packrat,general_qol,Mr-Sithel/packrat,1,1,29,4.2,"FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",https://github.com/Mr-Sithel/packrat,medium

--- a/ffxi-addon-catalog-normalized.json
+++ b/ffxi-addon-catalog-normalized.json
@@ -859,11 +859,12 @@
     "addon_name": "Readycheck",
     "category": "general_qol",
     "repos": [
+      "Lydya-nick77/readycheck",
       "iLVL-Key/FFXI"
     ],
-    "repo_count": 1,
+    "repo_count": 2,
     "best_repo_stars": 22,
-    "freshness_max": 5,
+    "freshness_max": 1,
     "opportunity_score": 4.83,
     "description": "Various FFXI projects",
     "description_source": "https://github.com/iLVL-Key/FFXI",
@@ -2321,11 +2322,12 @@
     "addon_name": "Smarttarget",
     "category": "combat_automation",
     "repos": [
-      "Icydeath/ffxi-addons"
+      "Icydeath/ffxi-addons",
+      "Phayde/Windower-addons"
     ],
-    "repo_count": 1,
+    "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 1,
+    "freshness_max": 8,
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -4545,5 +4547,200 @@
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "low"
+  },
+  {
+    "addon_key": "digskill",
+    "addon_name": "Digskill",
+    "category": "general_qol",
+    "repos": [
+      "Phayde/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 8,
+    "opportunity_score": 4.2,
+    "description": "A collection of addons for FFXI Windower",
+    "description_source": "https://github.com/Phayde/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trashit",
+    "addon_name": "Trashit",
+    "category": "general_qol",
+    "repos": [
+      "Phayde/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 8,
+    "opportunity_score": 4.2,
+    "description": "A collection of addons for FFXI Windower",
+    "description_source": "https://github.com/Phayde/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanaclock",
+    "addon_name": "Vanaclock",
+    "category": "general_qol",
+    "repos": [
+      "BagTown/vanaclock"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 25,
+    "opportunity_score": 4.2,
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "description_source": "https://github.com/BagTown/vanaclock",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanatime",
+    "addon_name": "Vanatime",
+    "category": "general_qol",
+    "repos": [
+      "BagTown/vanaclock"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 25,
+    "opportunity_score": 4.2,
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "description_source": "https://github.com/BagTown/vanaclock",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fasttarget",
+    "addon_name": "Fasttarget",
+    "category": "general_qol",
+    "repos": [
+      "LordAttilas/FastTarget"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 6,
+    "opportunity_score": 4.2,
+    "description": "Windower 4 addon for FFXI that allow quicker target change",
+    "description_source": "https://github.com/LordAttilas/FastTarget",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fancytrusts",
+    "addon_name": "Fancytrusts",
+    "category": "general_qol",
+    "repos": [
+      "ariel-logos/FancyTrusts"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 5,
+    "freshness_max": 14,
+    "opportunity_score": 4.2,
+    "description": "A fancy UI to manage trusts",
+    "description_source": "https://github.com/ariel-logos/FancyTrusts",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "closetcleaner2",
+    "addon_name": "Closetcleaner2",
+    "category": "general_qol",
+    "repos": [
+      "Gol-exe/closetCleaner2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 0,
+    "opportunity_score": 4.2,
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "description_source": "https://github.com/Gol-exe/closetCleaner2",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "luaparser",
+    "addon_name": "Luaparser",
+    "category": "general_qol",
+    "repos": [
+      "Gol-exe/closetCleaner2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 0,
+    "opportunity_score": 4.2,
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "description_source": "https://github.com/Gol-exe/closetCleaner2",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "weeklier",
+    "addon_name": "Weeklier",
+    "category": "general_qol",
+    "repos": [
+      "patheed-ffxi/weeklier"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.",
+    "description_source": "https://github.com/patheed-ffxi/weeklier",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "mogchat",
+    "addon_name": "Mogchat",
+    "category": "general_qol",
+    "repos": [
+      "glitchv0/mogchat"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 1,
+    "opportunity_score": 4.2,
+    "description": "AIM/ICQ style FFXI chat addon",
+    "description_source": "https://github.com/glitchv0/mogchat",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dpsmeter",
+    "addon_name": "Dpsmeter",
+    "category": "general_qol",
+    "repos": [
+      "cybersoulwing/dpsmeter"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 12,
+    "opportunity_score": 4.2,
+    "description": "FFXI Windower addon",
+    "description_source": "https://github.com/cybersoulwing/dpsmeter",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "automining",
+    "addon_name": "Automining",
+    "category": "general_qol",
+    "repos": [
+      "cybersoulwing/AutoMining"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 14,
+    "opportunity_score": 4.2,
+    "description": "FFXI Windower addon",
+    "description_source": "https://github.com/cybersoulwing/AutoMining",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "packrat",
+    "addon_name": "Packrat",
+    "category": "general_qol",
+    "repos": [
+      "Mr-Sithel/packrat"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 29,
+    "opportunity_score": 4.2,
+    "description": "FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",
+    "description_source": "https://github.com/Mr-Sithel/packrat",
+    "description_confidence": "medium"
   }
 ]

--- a/ffxi_addons_index_raw.json
+++ b/ffxi_addons_index_raw.json
@@ -1,40 +1,176 @@
 [
   {
-    "repo": "ProjectTako/ffxi-addons",
-    "stars": 99,
-    "pushed_at": "2022-11-09T19:45:51Z",
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "repo": "AkadenTK/enemybar2",
+    "stars": 19,
+    "pushed_at": "2021-01-30T19:48:45Z",
+    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
     "addon_dirs": [
-      "allseeingeye",
-      "debuff-tracker",
-      "equipviewer",
-      "fastcs",
-      "menus",
-      "partybuffs",
-      "react",
-      "scanzone",
-      "turnaround"
+      "icons"
     ]
   },
   {
-    "repo": "Ivaar/Windower-addons",
-    "stars": 79,
-    "pushed_at": "2023-09-12T03:56:46Z",
-    "description": "FFXI Windower addons",
+    "repo": "AkadenTK/superwarp",
+    "stars": 55,
+    "pushed_at": "2026-03-18T13:55:18Z",
+    "description": "Addon for Windower 4 for FFXI that allows text commands to utilize homepoint, waypoint and survival guide teleport npcs",
     "addon_dirs": [
-      "AuctionHelper",
-      "AutoCOR",
-      "AutoDNC",
-      "AutoGEO",
-      "ChatMan",
-      "PorterPacker",
-      "QuestLog",
-      "SellNPC",
-      "Singer",
-      "Trade",
-      "TradeNPC",
-      "chococard",
-      "htmb"
+      "map"
+    ]
+  },
+  {
+    "repo": "Akirane/XIVHotbar",
+    "stars": 18,
+    "pushed_at": "2020-12-26T23:55:51Z",
+    "description": "",
+    "addon_dirs": [
+      "data",
+      "priv_res",
+      "themes"
+    ]
+  },
+  {
+    "repo": "AliekberFFXI/xivcrossbar",
+    "stars": 17,
+    "pushed_at": "2022-09-15T22:03:23Z",
+    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
+    "addon_dirs": [
+      "libs",
+      "themes",
+      "ui"
+    ]
+  },
+  {
+    "repo": "ariel-logos/FancyTrusts",
+    "stars": 5,
+    "pushed_at": "2026-04-09T10:34:01Z",
+    "description": "A fancy UI to manage trusts",
+    "addon_dirs": [
+      "fancytrusts"
+    ]
+  },
+  {
+    "repo": "BagTown/vanaclock",
+    "stars": 3,
+    "pushed_at": "2026-03-30T01:43:40Z",
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "addon_dirs": [
+      "vanaclock",
+      "vanatime"
+    ]
+  },
+  {
+    "repo": "Bryenne-Sylph/tourist",
+    "stars": 3,
+    "pushed_at": "2026-03-15T20:10:54Z",
+    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
+    "addon_dirs": [
+      "tourist"
+    ]
+  },
+  {
+    "repo": "cybersoulwing/AutoMining",
+    "stars": 0,
+    "pushed_at": "2026-04-09T21:16:04Z",
+    "description": "FFXI Windower addon",
+    "addon_dirs": [
+      "automining"
+    ]
+  },
+  {
+    "repo": "cybersoulwing/dpsmeter",
+    "stars": 0,
+    "pushed_at": "2026-04-12T01:09:08Z",
+    "description": "FFXI Windower addon",
+    "addon_dirs": [
+      "dpsmeter"
+    ]
+  },
+  {
+    "repo": "cyritegamestudios/trust",
+    "stars": 49,
+    "pushed_at": "2026-04-23T16:00:56Z",
+    "description": "Windower 4 addon for FFXI to automate your character in battle.",
+    "addon_dirs": [
+      "trust"
+    ]
+  },
+  {
+    "repo": "DiscipleOfEris/Windower4Addons",
+    "stars": 12,
+    "pushed_at": "2024-02-18T18:22:59Z",
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "addon_dirs": [
+      "EraDebuffed",
+      "EraDistancePlus",
+      "EraInfoBar",
+      "EraJobChange",
+      "EraMobDrops",
+      "EraMobLevel",
+      "EraPointWatch",
+      "EraScoreboard",
+      "FastFollow",
+      "SendTarget",
+      "assist"
+    ]
+  },
+  {
+    "repo": "ekrividus/autoAssist",
+    "stars": 13,
+    "pushed_at": "2022-11-26T19:34:33Z",
+    "description": "An ffxi windower addon to automatically assist a party member in combat",
+    "addon_dirs": []
+  },
+  {
+    "repo": "flippant/parse",
+    "stars": 15,
+    "pushed_at": "2023-08-12T01:51:20Z",
+    "description": "FFXI Parser Addon for Windower",
+    "addon_dirs": []
+  },
+  {
+    "repo": "glitchv0/mogchat",
+    "stars": 0,
+    "pushed_at": "2026-04-22T15:44:33Z",
+    "description": "AIM/ICQ style FFXI chat addon",
+    "addon_dirs": [
+      "mogchat"
+    ]
+  },
+  {
+    "repo": "Gol-exe/closetCleaner2",
+    "stars": 0,
+    "pushed_at": "2026-04-23T20:03:49Z",
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "addon_dirs": [
+      "closetcleaner2",
+      "luaparser"
+    ]
+  },
+  {
+    "repo": "HealsCodes/statustimers",
+    "stars": 15,
+    "pushed_at": "2026-03-01T14:25:55Z",
+    "description": "Statustimers for Ashita v4",
+    "addon_dirs": [
+      "addons"
+    ]
+  },
+  {
+    "repo": "HealsCodes/XIPivot",
+    "stars": 61,
+    "pushed_at": "2026-01-31T13:44:31Z",
+    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
+    "addon_dirs": [
+      "XIPivot"
+    ]
+  },
+  {
+    "repo": "HiPotionQ8/XIchecklist",
+    "stars": 4,
+    "pushed_at": "2026-04-23T09:57:29Z",
+    "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
+    "addon_dirs": [
+      "XIchecklist"
     ]
   },
   {
@@ -186,21 +322,30 @@
     ]
   },
   {
-    "repo": "HealsCodes/XIPivot",
-    "stars": 61,
-    "pushed_at": "2026-01-31T13:44:31Z",
-    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
+    "repo": "iLVL-Key/FFXI",
+    "stars": 22,
+    "pushed_at": "2026-04-22T15:03:22Z",
+    "description": "Various FFXI projects",
     "addon_dirs": [
-      "XIPivot"
-    ]
-  },
-  {
-    "repo": "AkadenTK/superwarp",
-    "stars": 55,
-    "pushed_at": "2026-03-18T13:55:18Z",
-    "description": "Addon for Windower 4 for FFXI that allows text commands to utilize homepoint, waypoint and survival guide teleport npcs",
-    "addon_dirs": [
-      "map"
+      "Attend",
+      "Bars",
+      "BattlePlan",
+      "Callouts",
+      "Exorcist",
+      "GaolPlan",
+      "Helper",
+      "Informer",
+      "Jingle",
+      "LLMChat",
+      "Leaderboard",
+      "ReadyCheck",
+      "Sweeper",
+      "TaskBar",
+      "VanaFacts",
+      "VanaPad",
+      "Vanity",
+      "ZNMTracker",
+      "emotes"
     ]
   },
   {
@@ -211,22 +356,24 @@
     "addon_dirs": []
   },
   {
-    "repo": "cyritegamestudios/trust",
-    "stars": 49,
-    "pushed_at": "2026-04-23T04:17:39Z",
-    "description": "Windower 4 addon for FFXI to automate your character in battle.",
+    "repo": "Ivaar/Windower-addons",
+    "stars": 79,
+    "pushed_at": "2023-09-12T03:56:46Z",
+    "description": "FFXI Windower addons",
     "addon_dirs": [
-      "trust"
-    ]
-  },
-  {
-    "repo": "Tylas11/XivParty",
-    "stars": 47,
-    "pushed_at": "2026-02-26T20:01:30Z",
-    "description": "A party list addon for Windower 4.",
-    "addon_dirs": [
-      "assets",
-      "layouts"
+      "AuctionHelper",
+      "AutoCOR",
+      "AutoDNC",
+      "AutoGEO",
+      "ChatMan",
+      "PorterPacker",
+      "QuestLog",
+      "SellNPC",
+      "Singer",
+      "Trade",
+      "TradeNPC",
+      "chococard",
+      "htmb"
     ]
   },
   {
@@ -271,31 +418,6 @@
     ]
   },
   {
-    "repo": "mousseng/xitools",
-    "stars": 29,
-    "pushed_at": "2026-03-10T17:38:26Z",
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "addon_dirs": [
-      "bluspells",
-      "chatty",
-      "colure",
-      "dxui",
-      "imrecast",
-      "libs",
-      "loggers",
-      "minimap-helper",
-      "omen",
-      "rcheck",
-      "relicge",
-      "repl",
-      "skillchain",
-      "strats",
-      "trials",
-      "wheel",
-      "xitools"
-    ]
-  },
-  {
     "repo": "lorand-ffxi/HealBot",
     "stars": 28,
     "pushed_at": "2018-05-22T20:21:49Z",
@@ -305,50 +427,21 @@
     ]
   },
   {
-    "repo": "iLVL-Key/FFXI",
-    "stars": 22,
-    "pushed_at": "2026-04-22T15:03:22Z",
-    "description": "Various FFXI projects",
+    "repo": "LordAttilas/FastTarget",
+    "stars": 0,
+    "pushed_at": "2026-04-18T01:11:58Z",
+    "description": "Windower 4 addon for FFXI that allow quicker target change",
     "addon_dirs": [
-      "Attend",
-      "Bars",
-      "BattlePlan",
-      "Callouts",
-      "Exorcist",
-      "GaolPlan",
-      "Helper",
-      "Informer",
-      "Jingle",
-      "LLMChat",
-      "Leaderboard",
-      "ReadyCheck",
-      "Sweeper",
-      "TaskBar",
-      "VanaFacts",
-      "VanaPad",
-      "Vanity",
-      "ZNMTracker",
-      "emotes"
+      "fasttarget"
     ]
   },
   {
-    "repo": "AkadenTK/enemybar2",
-    "stars": 19,
-    "pushed_at": "2021-01-30T19:48:45Z",
-    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
+    "repo": "Lydya-nick77/readycheck",
+    "stars": 0,
+    "pushed_at": "2026-04-12T14:11:47Z",
+    "description": "FFXI addon to execute a WoW Style Readycheck with the party/alliance",
     "addon_dirs": [
-      "icons"
-    ]
-  },
-  {
-    "repo": "Akirane/XIVHotbar",
-    "stars": 18,
-    "pushed_at": "2020-12-26T23:55:51Z",
-    "description": "",
-    "addon_dirs": [
-      "data",
-      "priv_res",
-      "themes"
+      "readycheck"
     ]
   },
   {
@@ -437,14 +530,37 @@
     ]
   },
   {
-    "repo": "AliekberFFXI/xivcrossbar",
-    "stars": 17,
-    "pushed_at": "2022-09-15T22:03:23Z",
-    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
+    "repo": "mousseng/xitools",
+    "stars": 29,
+    "pushed_at": "2026-03-10T17:38:26Z",
+    "description": "Some addons and plugins for FFXI (Ashita)",
     "addon_dirs": [
+      "bluspells",
+      "chatty",
+      "colure",
+      "dxui",
+      "imrecast",
       "libs",
-      "themes",
-      "ui"
+      "loggers",
+      "minimap-helper",
+      "omen",
+      "rcheck",
+      "relicge",
+      "repl",
+      "skillchain",
+      "strats",
+      "trials",
+      "wheel",
+      "xitools"
+    ]
+  },
+  {
+    "repo": "Mr-Sithel/packrat",
+    "stars": 1,
+    "pushed_at": "2026-03-25T06:26:58Z",
+    "description": "FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",
+    "addon_dirs": [
+      "packrat"
     ]
   },
   {
@@ -533,95 +649,6 @@
     ]
   },
   {
-    "repo": "ZeromusXYZ/PacketViewerLogViewer",
-    "stars": 17,
-    "pushed_at": "2023-05-18T06:00:22Z",
-    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
-    "addon_dirs": [
-      "Properties",
-      "Res",
-      "data",
-      "forms",
-      "helpers",
-      "redist"
-    ]
-  },
-  {
-    "repo": "flippant/parse",
-    "stars": 15,
-    "pushed_at": "2023-08-12T01:51:20Z",
-    "description": "FFXI Parser Addon for Windower",
-    "addon_dirs": []
-  },
-  {
-    "repo": "HealsCodes/statustimers",
-    "stars": 15,
-    "pushed_at": "2026-03-01T14:25:55Z",
-    "description": "Statustimers for Ashita v4",
-    "addon_dirs": [
-      "addons"
-    ]
-  },
-  {
-    "repo": "ValokAsura/WindowerAddons",
-    "stars": 14,
-    "pushed_at": "2023-02-04T00:29:37Z",
-    "description": "",
-    "addon_dirs": [
-      "Bursting",
-      "CrystalTrader",
-      "MagicAssistant",
-      "QuickTrade 2",
-      "QuickTrade"
-    ]
-  },
-  {
-    "repo": "ekrividus/autoAssist",
-    "stars": 13,
-    "pushed_at": "2022-11-26T19:34:33Z",
-    "description": "An ffxi windower addon to automatically assist a party member in combat",
-    "addon_dirs": []
-  },
-  {
-    "repo": "Technyze/XIVHotbar2",
-    "stars": 13,
-    "pushed_at": "2023-03-12T03:29:46Z",
-    "description": "",
-    "addon_dirs": [
-      "data",
-      "priv_res",
-      "themes"
-    ]
-  },
-  {
-    "repo": "DiscipleOfEris/Windower4Addons",
-    "stars": 12,
-    "pushed_at": "2024-02-18T18:22:59Z",
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "addon_dirs": [
-      "EraDebuffed",
-      "EraDistancePlus",
-      "EraInfoBar",
-      "EraJobChange",
-      "EraMobDrops",
-      "EraMobLevel",
-      "EraPointWatch",
-      "EraScoreboard",
-      "FastFollow",
-      "SendTarget",
-      "assist"
-    ]
-  },
-  {
-    "repo": "HiPotionQ8/XIchecklist",
-    "stars": 4,
-    "pushed_at": "2026-04-23T09:57:29Z",
-    "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
-    "addon_dirs": [
-      "XIchecklist"
-    ]
-  },
-  {
     "repo": "onimitch/ffxi-zonename",
     "stars": 4,
     "pushed_at": "2026-04-05T14:44:54Z",
@@ -629,12 +656,40 @@
     "addon_dirs": []
   },
   {
-    "repo": "Bryenne-Sylph/tourist",
-    "stars": 3,
-    "pushed_at": "2026-03-15T20:10:54Z",
-    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
+    "repo": "patheed-ffxi/weeklier",
+    "stars": 0,
+    "pushed_at": "2026-04-18T13:06:18Z",
+    "description": "An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.",
     "addon_dirs": [
-      "tourist"
+      "weeklier"
+    ]
+  },
+  {
+    "repo": "Phayde/Windower-addons",
+    "stars": 1,
+    "pushed_at": "2026-04-16T02:53:51Z",
+    "description": "A collection of addons for FFXI Windower",
+    "addon_dirs": [
+      "digskill",
+      "smarttarget",
+      "trashit"
+    ]
+  },
+  {
+    "repo": "ProjectTako/ffxi-addons",
+    "stars": 99,
+    "pushed_at": "2022-11-09T19:45:51Z",
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "addon_dirs": [
+      "allseeingeye",
+      "debuff-tracker",
+      "equipviewer",
+      "fastcs",
+      "menus",
+      "partybuffs",
+      "react",
+      "scanzone",
+      "turnaround"
     ]
   },
   {
@@ -666,5 +721,53 @@
     "pushed_at": "2026-03-20T01:38:26Z",
     "description": "FFXI - Ashita v4.3 Addon - Zone Line Visualizer",
     "addon_dirs": []
+  },
+  {
+    "repo": "Technyze/XIVHotbar2",
+    "stars": 13,
+    "pushed_at": "2023-03-12T03:29:46Z",
+    "description": "",
+    "addon_dirs": [
+      "data",
+      "priv_res",
+      "themes"
+    ]
+  },
+  {
+    "repo": "Tylas11/XivParty",
+    "stars": 47,
+    "pushed_at": "2026-02-26T20:01:30Z",
+    "description": "A party list addon for Windower 4.",
+    "addon_dirs": [
+      "assets",
+      "layouts"
+    ]
+  },
+  {
+    "repo": "ValokAsura/WindowerAddons",
+    "stars": 14,
+    "pushed_at": "2023-02-04T00:29:37Z",
+    "description": "",
+    "addon_dirs": [
+      "Bursting",
+      "CrystalTrader",
+      "MagicAssistant",
+      "QuickTrade 2",
+      "QuickTrade"
+    ]
+  },
+  {
+    "repo": "ZeromusXYZ/PacketViewerLogViewer",
+    "stars": 17,
+    "pushed_at": "2023-05-18T06:00:22Z",
+    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
+    "addon_dirs": [
+      "Properties",
+      "Res",
+      "data",
+      "forms",
+      "helpers",
+      "redist"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
4h repository maintenance sync for catalog/index/docs artifacts.

## What changed
### Newly added repos
- `Phayde/Windower-addons`
- `Lydya-nick77/readycheck`
- `BagTown/vanaclock`
- `LordAttilas/FastTarget`
- `ariel-logos/FancyTrusts`
- `Gol-exe/closetCleaner2`
- `patheed-ffxi/weeklier`
- `glitchv0/mogchat`
- `cybersoulwing/dpsmeter`
- `cybersoulwing/AutoMining`
- `Mr-Sithel/packrat`

### Newly added addon entries
- `digskill`
- `trashit`
- `vanaclock`
- `vanatime`
- `fasttarget`
- `fancytrusts`
- `closetcleaner2`
- `luaparser`
- `weeklier`
- `mogchat`
- `dpsmeter`
- `automining`
- `packrat`

### Updated addon mappings
- `readycheck` now includes `Lydya-nick77/readycheck`
- `smarttarget` now includes `Phayde/Windower-addons`

### Removed/stale entries
- Repos removed: none
- Addons removed as stale: none

## Confidence notes
- **High confidence**: repo existence + metadata (stars, timestamps, descriptions) refreshed via GitHub API.
- **Medium confidence**: addon discovery from explicit addon directory names in multi-addon repos.
- **Lower confidence**: some single-repo projects may include helper modules alongside addon code (`luaparser` classification risk).

## Validation
- `./scripts/validate.sh` passed (with expected local warnings for missing `lua`/`luac` runtime in this environment).
- `python3 -m json.tool` passed for both JSON artifacts.
- CSV regenerated from normalized JSON.

## Scope check
Changes are scoped to:
- `ffxi_addons_index_raw.json`
- `ffxi-addon-catalog-normalized.json`
- `ffxi-addon-catalog-normalized.csv`
- `docs/sync-2026-04-24-0400.md`

No merge to `main` performed.
