### PR TITLE
chore(sync): 4h catalog refresh (2026-04-24 0800 UTC)

### DIFF
--- a/docs/sync-2026-04-24-0400.md
+++ b/docs/sync-2026-04-24-0400.md
@@ -1,0 +1,61 @@
+# 4h Sync Report — 2026-04-24 04:00 UTC
+
+## Scope
+Catalog/index/docs maintenance only:
+- `ffxi_addons_index_raw.json`
+- `ffxi-addon-catalog-normalized.json`
+- `ffxi-addon-catalog-normalized.csv`
+- `docs/sync-2026-04-24-0400.md`
+
+## Repository deltas
+### Added repos
+- `Phayde/Windower-addons`
+- `Lydya-nick77/readycheck`
+- `BagTown/vanaclock`
+- `LordAttilas/FastTarget`
+- `ariel-logos/FancyTrusts`
+- `Gol-exe/closetCleaner2`
+- `patheed-ffxi/weeklier`
+- `glitchv0/mogchat`
+- `cybersoulwing/dpsmeter`
+- `cybersoulwing/AutoMining`
+- `Mr-Sithel/packrat`
+
+### Updated repo metadata
+- Refreshed stars / `pushed_at` / descriptions for indexed repositories using GitHub API.
+
+### Removed repos
+- None in this sync.
+
+## Addon deltas (normalized catalog)
+### Newly added addon entries
+- `digskill`
+- `trashit`
+- `vanaclock`
+- `vanatime`
+- `fasttarget`
+- `fancytrusts`
+- `closetcleaner2`
+- `luaparser`
+- `weeklier`
+- `mogchat`
+- `dpsmeter`
+- `automining`
+- `packrat`
+
+### Updated addon mappings
+- `readycheck` now includes `Lydya-nick77/readycheck` as a source repo.
+- `smarttarget` now includes `Phayde/Windower-addons` as a source repo.
+
+### Removed/stale addon entries
+- None removed in this pass.
+
+## Confidence notes
+- **High confidence**: repo existence/metadata (stars, timestamps, descriptions) from GitHub API.
+- **Medium confidence**: addon extraction for multi-addon repositories where directory names map directly to addon names.
+- **Lower confidence**: some single-purpose/smaller repos may include support modules mixed with addon code (e.g., `luaparser` in `closetCleaner2`).
+
+## Validation
+- Validation script passed: `./scripts/validate.sh`
+- JSON artifacts parse cleanly (`python3 -m json.tool`).
+- CSV regenerated from normalized JSON with matching row count.

--- a/docs/sync-2026-04-24-0800.md
+++ b/docs/sync-2026-04-24-0800.md
@@ -1,0 +1,48 @@
+# 4h Sync Report — 2026-04-24 08:00 UTC
+
+## Scope
+Catalog/index/docs maintenance only:
+- `ffxi_addons_index_raw.json`
+- `ffxi-addon-catalog-normalized.json`
+- `ffxi-addon-catalog-normalized.csv`
+- `docs/sync-2026-04-24-0800.md`
+
+## Repository deltas
+### Added repos
+- `garyfromwork/Stats`
+- `DiscipleOfEris/NpcInteract`
+- `djlabbe/MogMover`
+- `rouzazari/magianws`
+- `DiscipleOfEris/MobLevel`
+- `ekrividus/autoMB`
+
+### Updated repo metadata
+- Refreshed stars / `pushed_at` / descriptions for indexed repositories from GitHub API (`gh repo view`).
+
+### Removed repos
+- None in this sync.
+
+## Addon deltas (normalized catalog)
+### Newly added addon entries
+- `stats`
+- `npcinteract`
+- `mogmover`
+- `magianws`
+- `moblevel`
+- `automb`
+
+### Updated addon mappings
+- Existing entries had `best_repo_stars` / `freshness_max` refreshed from updated repo metadata.
+
+### Removed/stale addon entries
+- None removed in this pass.
+
+## Confidence notes
+- **High confidence**: repo existence + metadata (stars, push timestamps, descriptions) from GitHub API.
+- **Medium confidence**: addon mapping for single-purpose repos where repo identity aligns directly to addon name.
+- **Lower confidence**: some repos may also include utility modules not modeled as standalone addons in this pass.
+
+## Validation
+- Validation script passed: `./scripts/validate.sh`
+- JSON artifacts parse cleanly (`python3 -m json.tool`).
+- CSV regenerated from normalized JSON.

--- a/ffxi-addon-catalog-normalized.csv
+++ b/ffxi-addon-catalog-normalized.csv
@@ -56,7 +56,7 @@ informer,Informer,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,ht
 jingle,Jingle,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 leaderboard,Leaderboard,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 llmchat,Llmchat,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-readycheck,Readycheck,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
+readycheck,Readycheck,general_qol,Lydya-nick77/readycheck;iLVL-Key/FFXI,2,22,1,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 sweeper,Sweeper,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 taskbar,Taskbar,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
 vanafacts,Vanafacts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
@@ -153,7 +153,7 @@ sendalltarget,Sendalltarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,F
 settarget,Settarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 simpleassist,Simpleassist,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 sirpopalot,Sirpopalot,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-smarttarget,Smarttarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
+smarttarget,Smarttarget,combat_automation,Icydeath/ffxi-addons;Phayde/Windower-addons,2,69,8,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 spellspammer,Spellspammer,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 stars,Stars,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 synergy,Synergy,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
@@ -294,3 +294,16 @@ tparty,Tparty,ui_gear,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addo
 treasury,Treasury,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 zonetimer,Zonetimer,travel_navigation,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
 healbot,Healbot,automation,Icydeath/ffxi-addons;Lygre/addons;lorand-ffxi/HealBot;mverteuil/windower4-addons,4,69,1,1.57,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low
+digskill,Digskill,general_qol,Phayde/Windower-addons,1,1,8,4.2,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,medium
+trashit,Trashit,general_qol,Phayde/Windower-addons,1,1,8,4.2,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,medium
+vanaclock,Vanaclock,general_qol,BagTown/vanaclock,1,3,25,4.2,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,medium
+vanatime,Vanatime,general_qol,BagTown/vanaclock,1,3,25,4.2,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,medium
+fasttarget,Fasttarget,general_qol,LordAttilas/FastTarget,1,0,6,4.2,Windower 4 addon for FFXI that allow quicker target change,https://github.com/LordAttilas/FastTarget,medium
+fancytrusts,Fancytrusts,general_qol,ariel-logos/FancyTrusts,1,5,14,4.2,A fancy UI to manage trusts,https://github.com/ariel-logos/FancyTrusts,medium
+closetcleaner2,Closetcleaner2,general_qol,Gol-exe/closetCleaner2,1,0,0,4.2,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,medium
+luaparser,Luaparser,general_qol,Gol-exe/closetCleaner2,1,0,0,4.2,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,medium
+weeklier,Weeklier,general_qol,patheed-ffxi/weeklier,1,0,5,4.2,An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.,https://github.com/patheed-ffxi/weeklier,medium
+mogchat,Mogchat,general_qol,glitchv0/mogchat,1,0,1,4.2,AIM/ICQ style FFXI chat addon,https://github.com/glitchv0/mogchat,medium
+dpsmeter,Dpsmeter,general_qol,cybersoulwing/dpsmeter,1,0,12,4.2,FFXI Windower addon,https://github.com/cybersoulwing/dpsmeter,medium
+automining,Automining,general_qol,cybersoulwing/AutoMining,1,0,14,4.2,FFXI Windower addon,https://github.com/cybersoulwing/AutoMining,medium
+packrat,Packrat,general_qol,Mr-Sithel/packrat,1,1,29,4.2,"FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",https://github.com/Mr-Sithel/packrat,medium

--- a/ffxi-addon-catalog-normalized.csv
+++ b/ffxi-addon-catalog-normalized.csv
@@ -1,309 +1,315 @@
-addon_key,addon_name,category,repos,repo_count,best_repo_stars,freshness_max,opportunity_score,description,description_source,description_confidence
-xipivot,XIpivot,general_qol,HealsCodes/XIPivot,1,61,5,4.83,FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs,https://github.com/HealsCodes/XIPivot,medium
-trust,Trust,automation,cyritegamestudios/trust,1,49,5,4.83,Windower 4 addon for FFXI to automate your character in battle.,https://github.com/cyritegamestudios/trust,medium
-xivparty,XIvparty,ui_gear,Tylas11/XivParty,1,47,5,4.83,A party list addon for Windower 4.,https://github.com/Tylas11/XivParty,medium
-atreplace,Atreplace,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-augments,Augments,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-chatfix,Chatfix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-clevel,Clevel,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-collector,Collector,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-dramagen,Dramagen,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-gilbox,Gilbox,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-indinope,Indinope,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-jobinit,Jobinit,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-kaomoji,Kaomoji,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-menufix,Menufix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-mousehalo,Mousehalo,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-ondemand,Ondemand,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-position_manager,Position Manager,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-readable,Readable,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-safeoboro,Safeoboro,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-silttracker,Silttracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-smeagol,Smeagol,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-special,Special,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-tellapart,Tellapart,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-tellfix,Tellfix,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-tiptoes,Tiptoes,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-tpsreport,Tpsreport,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-trialtracker,Trialtracker,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-useall,Useall,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-waveback,Waveback,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-weathermon,Weathermon,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-witnessprotection,Witnessprotection,general_qol,lili-ffxi/FFXI-Addons,1,35,5,4.83,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium
-bluspells,Bluspells,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-chatty,Chatty,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-colure,Colure,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-dxui,Dxui,ui_gear,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-imrecast,Imrecast,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-loggers,Loggers,diagnostics,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-minimap-helper,Minimap Helper,automation,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-rcheck,Rcheck,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-relicge,Relicge,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-repl,Repl,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-strats,Strats,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-trials,Trials,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-wheel,Wheel,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-xitools,XItools,general_qol,mousseng/xitools,1,29,5,4.83,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-attend,Attend,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-bars,Bars,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-battleplan,Battleplan,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-callouts,Callouts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-emotes,Emotes,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-exorcist,Exorcist,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-gaolplan,Gaolplan,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-helper,Helper,automation,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-informer,Informer,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-jingle,Jingle,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-leaderboard,Leaderboard,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-llmchat,Llmchat,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-readycheck,Readycheck,general_qol,Lydya-nick77/readycheck;iLVL-Key/FFXI,2,22,1,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-sweeper,Sweeper,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-taskbar,Taskbar,ui_gear,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-vanafacts,Vanafacts,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-vanapad,Vanapad,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-vanity,Vanity,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-znmtracker,Znmtracker,general_qol,iLVL-Key/FFXI,1,22,5,4.83,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium
-addons,Addons,diagnostics,HealsCodes/statustimers,1,15,5,4.83,Statustimers for Ashita v4,https://github.com/HealsCodes/statustimers,medium
-ffxi-zonename,FFXI Zonename,travel_navigation,onimitch/ffxi-zonename,1,4,5,4.83,This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.,https://github.com/onimitch/ffxi-zonename,medium
-xichecklist,XIchecklist,travel_navigation,HiPotionQ8/XIchecklist,1,4,5,4.83,"windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",https://github.com/HiPotionQ8/XIchecklist,medium
-tourist,Tourist,travel_navigation,Bryenne-Sylph/tourist,1,3,5,4.83,An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ,https://github.com/Bryenne-Sylph/tourist,medium
-gmtools,Gmtools,automation,SQLCommit/GMTools,1,2,5,4.83,FFXI - Ashita v4.3 Addon - LSB GM Command Helper,https://github.com/SQLCommit/GMTools,medium
-lootscope,Lootscope,economy_inventory,SQLCommit/LootScope,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Loot Drop Tracker,https://github.com/SQLCommit/LootScope,medium
-memscope,Memscope,diagnostics,SQLCommit/MemScope,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage,https://github.com/SQLCommit/MemScope,medium
-zonelines,Zonelines,travel_navigation,SQLCommit/ZoneLines,1,2,5,4.83,FFXI - Ashita v4.3 Addon - Zone Line Visualizer,https://github.com/SQLCommit/ZoneLines,medium
-debuff-tracker,Debuff Tracker,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-menus,Menus,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-scanzone,Scanzone,travel_navigation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-turnaround,Turnaround,automation,ProjectTako/ffxi-addons,1,99,2,3.78,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-autodnc,Autodnc,automation,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-chococard,Chococard,general_qol,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-questlog,Questlog,general_qol,Ivaar/Windower-addons,1,79,2,3.78,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-packetviewerlogviewer,Packetviewerlogviewer,diagnostics,ZeromusXYZ/PacketViewerLogViewer,1,17,2,3.78,PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp,https://github.com/ZeromusXYZ/PacketViewerLogViewer,medium
-ui,Ui,ui_gear,AliekberFFXI/xivcrossbar,1,17,2,3.78,FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar,https://github.com/AliekberFFXI/xivcrossbar,medium
-bursting,Bursting,general_qol,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
-crystaltrader,Crystaltrader,economy_inventory,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
-quicktrade_2,Quicktrade 2,ui_gear,ValokAsura/WindowerAddons,1,14,2,3.78,,,low
-autoassist,Autoassist,automation,ekrividus/autoAssist,1,13,2,3.78,An ffxi windower addon to automatically assist a party member in combat,https://github.com/ekrividus/autoAssist,medium
-xivhotbar2,XIvhotbar2,ui_gear,Technyze/XIVHotbar2,1,13,2,3.78,,,low
-assist,Assist,automation,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-eradebuffed,Eradebuffed,combat_automation,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-eradistanceplus,Eradistanceplus,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-erainfobar,Erainfobar,ui_gear,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-erajobchange,Erajobchange,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-eramobdrops,Eramobdrops,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-eramoblevel,Eramoblevel,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-erapointwatch,Erapointwatch,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-erascoreboard,Erascoreboard,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-fastfollow,Fastfollow,general_qol,DiscipleOfEris/Windower4Addons,1,12,2,3.78,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium
-clickfind,Clickfind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-dupefind,Dupefind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-friendzone,Friendzone,travel_navigation,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-omen,Omen,general_qol,Icydeath/ffxi-addons;mousseng/xitools,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-posfind,Posfind,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-statsearch,Statsearch,general_qol,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-superwarp,Superwarp,travel_navigation,AkadenTK/superwarp;Icydeath/ffxi-addons,2,69,5,3.71,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-ambuloot,Ambuloot,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-attackid,Attackid,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-attackwithme,Attackwithme,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autochain,Autochain,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autopup,Autopup,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autoraise,Autoraise,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autoskillchain,Autoskillchain,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autounm,Autounm,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autovw,Autovw,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autowatch,Autowatch,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-blist,Blist,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-canteen,Canteen,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-capetrader,Capetrader,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-charmed,Charmed,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-checkparam,Checkparam,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-crb_addon,Crb Addon,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-cureplease_addon,Cureplease Addon,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-currencies,Currencies,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-distanceplus,Distanceplus,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-drop,Drop,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-eschachest,Eschachest,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-export_items,Export Items,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-ffxikeys,FFXIkeys,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-finalalert,Finalalert,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-followme,Followme,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-giltracker,Giltracker,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-jobchange,Jobchange,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-locke,Locke,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-lockpick,Lockpick,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-maga,Maga,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-masstrade,Masstrade,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-moveitems,Moveitems,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-myhome,Myhome,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-myomen,Myomen,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-nnitimer,Nnitimer,diagnostics,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-noknock,Noknock,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-oneoffs,Oneoffs,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-partypets,Partypets,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-petparty,Petparty,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-positions,Positions,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-repeater,Repeater,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-roe,Roe,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-rolldistance,Rolldistance,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-rtfm,Rtfm,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-runicportal,Runicportal,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-schskillchain,Schskillchain,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-scriptedextender,Scriptedextender,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-sendalltarget,Sendalltarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-settarget,Settarget,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-simpleassist,Simpleassist,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-sirpopalot,Sirpopalot,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-smarttarget,Smarttarget,combat_automation,Icydeath/ffxi-addons;Phayde/Windower-addons,2,69,8,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-spellspammer,Spellspammer,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-stars,Stars,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-synergy,Synergy,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-targeter,Targeter,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-targetinfoex,Targetinfoex,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-targetplus,Targetplus,combat_automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-thfknife,Thfknife,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-tonic,Tonic,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-trader,Trader,economy_inventory,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-triggers,Triggers,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-valkyrie,Valkyrie,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-voidwalker,Voidwalker,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-voidwatch,Voidwatch,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-vwpop,Vwpop,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-warpmenu,Warpmenu,travel_navigation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-where,Where,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-widescantool,Widescantool,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-woehelper,Woehelper,automation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-xivcrossbar,XIvcrossbar,ui_gear,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-zenimonsnap,Zenimonsnap,general_qol,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-zonename,Zonename,travel_navigation,Icydeath/ffxi-addons,1,69,1,3.43,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-enemybar2,Enemybar2,ui_gear,AkadenTK/enemybar2,1,19,1,3.43,Evolution of the simpler Windower addon that displays a target health bar prominently onscreen,https://github.com/AkadenTK/enemybar2,medium
-ase,Ase,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-autoinvite,Autoinvite,automation,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-broseem,Broseem,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-impalert,Impalert,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-pet_fix,Pet Fix,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-plugin_manager,Plugin Manager,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-rollbot,Rollbot,automation,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-skilluptracker,Skilluptracker,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-stna,Stna,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-stopwatch,Stopwatch,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-text,Text,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-translate,Translate,general_qol,Lygre/addons,1,18,1,3.43,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-xivhotbar,XIvhotbar,ui_gear,Akirane/XIVHotbar,1,18,1,3.43,,,low
-barfiller,Barfiller,ui_gear,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-chars,Chars,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-chatlink,Chatlink,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-enemybar,Enemybar,ui_gear,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-ffxicaddieprovider,FFXIcaddieprovider,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-highlight,Highlight,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-inforeplacer,Inforeplacer,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-lazy,Lazy,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-nostrum,Nostrum,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-ohshi,Ohshi,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-plasmon,Plasmon,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-reive,Reive,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-rhombus,Rhombus,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-salvage2,Salvage2,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-satacast,Satacast,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-setbgm,Setbgm,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-strathelper,Strathelper,automation,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-taps,Taps,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-targetinfo,Targetinfo,combat_automation,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-truesight,Truesight,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-visiblefavor,Visiblefavor,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-yush,Yush,general_qol,mverteuil/windower4-addons,1,17,1,3.43,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium
-skillchain,Skillchain,combat_automation,Lygre/addons;mousseng/xitools;mverteuil/windower4-addons,3,29,5,3.26,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium
-allseeingeye,Allseeingeye,general_qol,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-equipviewer,Equipviewer,automation,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-partybuffs,Partybuffs,automation,Lygre/addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-react,React,automation,Icydeath/ffxi-addons;ProjectTako/ffxi-addons,2,99,2,2.66,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium
-autocor,Autocor,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-autogeo,Autogeo,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-chatman,Chatman,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-htmb,Htmb,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-porterpacker,Porterpacker,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-singer,Singer,general_qol,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-tradenpc,Tradenpc,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons,2,79,2,2.66,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-magicassistant,Magicassistant,automation,Icydeath/ffxi-addons;ValokAsura/WindowerAddons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-quicktrade,Quicktrade,ui_gear,Icydeath/ffxi-addons;ValokAsura/WindowerAddons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-sendtarget,Sendtarget,combat_automation,DiscipleOfEris/Windower4Addons;Icydeath/ffxi-addons,2,69,2,2.66,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-parse,Parse,diagnostics,Lygre/addons;flippant/parse,2,18,2,2.66,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-anchor,Anchor,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autocontrol,Autocontrol,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autojoin,Autojoin,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autows,Autows,automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-azuresets,Azuresets,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-clock,Clock,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-dostuff,Dostuff,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-dynamishelper,Dynamishelper,automation,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-fisher,Fisher,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-lottery,Lottery,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-macrochanger,Macrochanger,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-porter,Porter,economy_inventory,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-send,Send,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-silence,Silence,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-subtarget,Subtarget,combat_automation,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-thtracker,Thtracker,general_qol,Icydeath/ffxi-addons;mverteuil/windower4-addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-timestamp,Timestamp,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-treasurepool,Treasurepool,general_qol,Icydeath/ffxi-addons;Lygre/addons,2,69,1,2.31,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autosynth,Autosynth,automation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-bluguide,Bluguide,travel_navigation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-boxdestroyer,Boxdestroyer,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-debuffed,Debuffed,combat_automation,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-digger,Digger,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-distance,Distance,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-gametime,Gametime,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-instals,Instals,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-latentchecker,Latentchecker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-linker,Linker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-ohnoyoudont,Ohnoyoudont,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-opensesame,Opensesame,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-packetviewer,Packetviewer,diagnostics,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-pettp,Pettp,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-pricer,Pricer,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-rolltracker,Rolltracker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-scoreboard,Scoreboard,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-speedchecker,Speedchecker,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-spellcheck,Spellcheck,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-sprint,Sprint,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-synthall,Synthall,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-update,Update,general_qol,Lygre/addons;mverteuil/windower4-addons,2,18,1,2.31,FFXI Windower Addons,https://github.com/Lygre/addons,medium
-skillchains,Skillchains,combat_automation,Icydeath/ffxi-addons;Ivaar/Skillchains;Lygre/addons;mverteuil/windower4-addons,4,69,3,2.27,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low
-auctionhelper,Auctionhelper,automation,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons,3,79,2,2.21,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-trade,Trade,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons,3,79,2,2.21,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium
-fastcs,Fastcs,general_qol,Icydeath/ffxi-addons;Lygre/addons;ProjectTako/ffxi-addons;mverteuil/windower4-addons,4,99,2,1.92,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,low
-sellnpc,Sellnpc,economy_inventory,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons;mverteuil/windower4-addons,4,79,2,1.92,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,low
-aecho,Aecho,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-autora,Autora,automation,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-battlemod,Battlemod,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-cancel,Cancel,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-consolebg,Consolebg,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-dressup,Dressup,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-enternity,Enternity,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-eval,Eval,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-findall,Findall,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-gearswap,Gearswap,ui_gear,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-invspace,Invspace,economy_inventory,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-itemizer,Itemizer,economy_inventory,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-logger,Logger,diagnostics,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-organizer,Organizer,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-pointwatch,Pointwatch,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-pouches,Pouches,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-shortcuts,Shortcuts,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-sparks,Sparks,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-tparty,Tparty,ui_gear,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-treasury,Treasury,general_qol,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-zonetimer,Zonetimer,travel_navigation,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons,3,69,1,1.86,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium
-healbot,Healbot,automation,Icydeath/ffxi-addons;Lygre/addons;lorand-ffxi/HealBot;mverteuil/windower4-addons,4,69,1,1.57,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low
-digskill,Digskill,general_qol,Phayde/Windower-addons,1,1,8,4.2,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,medium
-trashit,Trashit,general_qol,Phayde/Windower-addons,1,1,8,4.2,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,medium
-vanaclock,Vanaclock,general_qol,BagTown/vanaclock,1,3,25,4.2,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,medium
-vanatime,Vanatime,general_qol,BagTown/vanaclock,1,3,25,4.2,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,medium
-fasttarget,Fasttarget,general_qol,LordAttilas/FastTarget,1,0,6,4.2,Windower 4 addon for FFXI that allow quicker target change,https://github.com/LordAttilas/FastTarget,medium
-fancytrusts,Fancytrusts,general_qol,ariel-logos/FancyTrusts,1,5,14,4.2,A fancy UI to manage trusts,https://github.com/ariel-logos/FancyTrusts,medium
-closetcleaner2,Closetcleaner2,general_qol,Gol-exe/closetCleaner2,1,0,0,4.2,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,medium
-luaparser,Luaparser,general_qol,Gol-exe/closetCleaner2,1,0,0,4.2,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,medium
-weeklier,Weeklier,general_qol,patheed-ffxi/weeklier,1,0,5,4.2,An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.,https://github.com/patheed-ffxi/weeklier,medium
-mogchat,Mogchat,general_qol,glitchv0/mogchat,1,0,1,4.2,AIM/ICQ style FFXI chat addon,https://github.com/glitchv0/mogchat,medium
-dpsmeter,Dpsmeter,general_qol,cybersoulwing/dpsmeter,1,0,12,4.2,FFXI Windower addon,https://github.com/cybersoulwing/dpsmeter,medium
-automining,Automining,general_qol,cybersoulwing/AutoMining,1,0,14,4.2,FFXI Windower addon,https://github.com/cybersoulwing/AutoMining,medium
-packrat,Packrat,general_qol,Mr-Sithel/packrat,1,1,29,4.2,"FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",https://github.com/Mr-Sithel/packrat,medium
+addon_key,addon_name,description,description_source,description_confidence,category,repo_count,best_repo_stars,freshness_max,opportunity_score,repos
+readycheck,Readycheck,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,2,22,5,4.83,Lydya-nick77/readycheck;iLVL-Key/FFXI
+addons,Addons,Statustimers for Ashita v4,https://github.com/HealsCodes/statustimers,medium,diagnostics,1,15,4,4.83,HealsCodes/statustimers
+atreplace,Atreplace,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+attend,Attend,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+augments,Augments,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+bars,Bars,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,ui_gear,1,22,5,4.83,iLVL-Key/FFXI
+battleplan,Battleplan,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,automation,1,22,5,4.83,iLVL-Key/FFXI
+bluspells,Bluspells,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+callouts,Callouts,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+chatfix,Chatfix,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+chatty,Chatty,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+clevel,Clevel,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+collector,Collector,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+colure,Colure,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+dramagen,Dramagen,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+dxui,Dxui,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,ui_gear,1,29,4,4.83,mousseng/xitools
+emotes,Emotes,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+exorcist,Exorcist,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+ffxi-zonename,FFXI Zonename,This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.,https://github.com/onimitch/ffxi-zonename,medium,travel_navigation,1,4,5,4.83,onimitch/ffxi-zonename
+gaolplan,Gaolplan,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,automation,1,22,5,4.83,iLVL-Key/FFXI
+gilbox,Gilbox,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+gmtools,Gmtools,FFXI - Ashita v4.3 Addon - LSB GM Command Helper,https://github.com/SQLCommit/GMTools,medium,automation,1,2,4,4.83,SQLCommit/GMTools
+helper,Helper,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,automation,1,22,5,4.83,iLVL-Key/FFXI
+imrecast,Imrecast,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+indinope,Indinope,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+informer,Informer,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+jingle,Jingle,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+jobinit,Jobinit,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+kaomoji,Kaomoji,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+leaderboard,Leaderboard,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+llmchat,Llmchat,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+loggers,Loggers,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,diagnostics,1,29,4,4.83,mousseng/xitools
+lootscope,Lootscope,FFXI - Ashita v4.3 Addon - Loot Drop Tracker,https://github.com/SQLCommit/LootScope,medium,economy_inventory,1,2,5,4.83,SQLCommit/LootScope
+memscope,Memscope,FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage,https://github.com/SQLCommit/MemScope,medium,diagnostics,1,2,4,4.83,SQLCommit/MemScope
+menufix,Menufix,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+minimap-helper,Minimap Helper,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,automation,1,29,4,4.83,mousseng/xitools
+mousehalo,Mousehalo,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+ondemand,Ondemand,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+position_manager,Position Manager,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+rcheck,Rcheck,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+readable,Readable,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+relicge,Relicge,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+repl,Repl,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+safeoboro,Safeoboro,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+silttracker,Silttracker,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+smeagol,Smeagol,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+special,Special,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+strats,Strats,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+sweeper,Sweeper,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+taskbar,Taskbar,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,ui_gear,1,22,5,4.83,iLVL-Key/FFXI
+tellapart,Tellapart,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+tellfix,Tellfix,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+tiptoes,Tiptoes,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+tourist,Tourist,An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ,https://github.com/Bryenne-Sylph/tourist,medium,travel_navigation,1,3,4,4.83,Bryenne-Sylph/tourist
+tpsreport,Tpsreport,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+trials,Trials,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+trialtracker,Trialtracker,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+trust,Trust,Windower 4 addon for FFXI to automate your character in battle.,https://github.com/cyritegamestudios/trust,medium,automation,1,49,5,4.83,cyritegamestudios/trust
+useall,Useall,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+vanafacts,Vanafacts,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+vanapad,Vanapad,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+vanity,Vanity,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+waveback,Waveback,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+weathermon,Weathermon,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+wheel,Wheel,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+witnessprotection,Witnessprotection,Addons I wrote for Final Fantasy XI. Compatible with Windower.,https://github.com/lili-ffxi/FFXI-Addons,medium,general_qol,1,35,4,4.83,lili-ffxi/FFXI-Addons
+xichecklist,XIchecklist,"windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",https://github.com/HiPotionQ8/XIchecklist,medium,travel_navigation,1,4,5,4.83,HiPotionQ8/XIchecklist
+xipivot,XIpivot,FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs,https://github.com/HealsCodes/XIPivot,medium,general_qol,1,61,4,4.83,HealsCodes/XIPivot
+xitools,XItools,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,general_qol,1,29,4,4.83,mousseng/xitools
+xivparty,XIvparty,A party list addon for Windower 4.,https://github.com/Tylas11/XivParty,medium,ui_gear,1,47,4,4.83,Tylas11/XivParty
+znmtracker,Znmtracker,Various FFXI projects,https://github.com/iLVL-Key/FFXI,medium,general_qol,1,22,5,4.83,iLVL-Key/FFXI
+zonelines,Zonelines,FFXI - Ashita v4.3 Addon - Zone Line Visualizer,https://github.com/SQLCommit/ZoneLines,medium,travel_navigation,1,2,4,4.83,SQLCommit/ZoneLines
+automining,Automining,FFXI Windower addon,https://github.com/cybersoulwing/AutoMining,medium,general_qol,1,0,5,4.2,cybersoulwing/AutoMining
+closetcleaner2,Closetcleaner2,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,medium,general_qol,1,0,5,4.2,Gol-exe/closetCleaner2
+digskill,Digskill,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,medium,general_qol,1,1,5,4.2,Phayde/Windower-addons
+dpsmeter,Dpsmeter,FFXI Windower addon,https://github.com/cybersoulwing/dpsmeter,medium,general_qol,1,0,5,4.2,cybersoulwing/dpsmeter
+fancytrusts,Fancytrusts,A fancy UI to manage trusts,https://github.com/ariel-logos/FancyTrusts,medium,general_qol,1,5,5,4.2,ariel-logos/FancyTrusts
+fasttarget,Fasttarget,Windower 4 addon for FFXI that allow quicker target change,https://github.com/LordAttilas/FastTarget,medium,general_qol,1,0,5,4.2,LordAttilas/FastTarget
+luaparser,Luaparser,Rework of the ClosetCleaner FFXI Windower Addon,https://github.com/Gol-exe/closetCleaner2,medium,general_qol,1,0,5,4.2,Gol-exe/closetCleaner2
+mogchat,Mogchat,AIM/ICQ style FFXI chat addon,https://github.com/glitchv0/mogchat,medium,general_qol,1,0,5,4.2,glitchv0/mogchat
+packrat,Packrat,"FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",https://github.com/Mr-Sithel/packrat,medium,general_qol,1,1,5,4.2,Mr-Sithel/packrat
+trashit,Trashit,A collection of addons for FFXI Windower,https://github.com/Phayde/Windower-addons,medium,general_qol,1,1,5,4.2,Phayde/Windower-addons
+vanaclock,Vanaclock,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,medium,general_qol,1,3,5,4.2,BagTown/vanaclock
+vanatime,Vanatime,Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.,https://github.com/BagTown/vanaclock,medium,general_qol,1,3,5,4.2,BagTown/vanaclock
+weeklier,Weeklier,An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.,https://github.com/patheed-ffxi/weeklier,medium,general_qol,1,0,5,4.2,patheed-ffxi/weeklier
+automb,autoMB,An ffxi windower addon to help with magic bursts,https://github.com/ekrividus/autoMB,medium,combat_automation,1,7,1,4.0,ekrividus/autoMB
+magianws,magianws,FFXI Windower addon that assists with Magian Weapon Skill Trials,https://github.com/rouzazari/magianws,medium,combat_automation,1,0,4,4.0,rouzazari/magianws
+moblevel,MobLevel,FFXI Windower addon that displays the level of the selected mob in their target box.,https://github.com/DiscipleOfEris/MobLevel,medium,ui_gear,1,3,1,4.0,DiscipleOfEris/MobLevel
+mogmover,MogMover,FFXI / Windower Addon - Automated Inventory Management,https://github.com/djlabbe/MogMover,medium,economy_inventory,1,0,4,4.0,djlabbe/MogMover
+npcinteract,NpcInteract,FFXI Windower addon for multiboxers to reduce tedious switching. Allow your alts to copy your main's NPC interactions.,https://github.com/DiscipleOfEris/NpcInteract,medium,automation,1,7,1,4.0,DiscipleOfEris/NpcInteract
+stats,Stats,"FFXI Windower Addon for tracking stats in game such as accuracy rate, min/max damage, spell debuff accuracy, ect.",https://github.com/garyfromwork/Stats,medium,diagnostics,1,1,4,4.0,garyfromwork/Stats
+assist,Assist,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,automation,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+autoassist,Autoassist,An ffxi windower addon to automatically assist a party member in combat,https://github.com/ekrividus/autoAssist,medium,automation,1,13,1,3.78,ekrividus/autoAssist
+autodnc,Autodnc,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,automation,1,79,1,3.78,Ivaar/Windower-addons
+bursting,Bursting,,,low,general_qol,1,14,1,3.78,ValokAsura/WindowerAddons
+chococard,Chococard,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,general_qol,1,79,1,3.78,Ivaar/Windower-addons
+crystaltrader,Crystaltrader,,,low,economy_inventory,1,14,1,3.78,ValokAsura/WindowerAddons
+debuff-tracker,Debuff Tracker,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium,automation,1,99,1,3.78,ProjectTako/ffxi-addons
+eradebuffed,Eradebuffed,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,combat_automation,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+eradistanceplus,Eradistanceplus,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,general_qol,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+erainfobar,Erainfobar,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,ui_gear,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+erajobchange,Erajobchange,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,general_qol,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+eramobdrops,Eramobdrops,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,general_qol,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+eramoblevel,Eramoblevel,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,general_qol,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+erapointwatch,Erapointwatch,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,general_qol,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+erascoreboard,Erascoreboard,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,general_qol,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+fastfollow,Fastfollow,Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.,https://github.com/DiscipleOfEris/Windower4Addons,medium,general_qol,1,12,1,3.78,DiscipleOfEris/Windower4Addons
+menus,Menus,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium,automation,1,99,1,3.78,ProjectTako/ffxi-addons
+packetviewerlogviewer,Packetviewerlogviewer,PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp,https://github.com/ZeromusXYZ/PacketViewerLogViewer,medium,diagnostics,1,17,1,3.78,ZeromusXYZ/PacketViewerLogViewer
+questlog,Questlog,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,general_qol,1,79,1,3.78,Ivaar/Windower-addons
+quicktrade_2,Quicktrade 2,,,low,ui_gear,1,14,1,3.78,ValokAsura/WindowerAddons
+scanzone,Scanzone,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium,travel_navigation,1,99,1,3.78,ProjectTako/ffxi-addons
+turnaround,Turnaround,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium,automation,1,99,1,3.78,ProjectTako/ffxi-addons
+ui,Ui,FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar,https://github.com/AliekberFFXI/xivcrossbar,medium,ui_gear,1,17,1,3.78,AliekberFFXI/xivcrossbar
+xivhotbar2,XIvhotbar2,,,low,ui_gear,1,13,1,3.78,Technyze/XIVHotbar2
+clickfind,Clickfind,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,4,3.71,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons
+dupefind,Dupefind,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,4,3.71,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons
+friendzone,Friendzone,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,travel_navigation,2,69,4,3.71,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons
+omen,Omen,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,4,3.71,Icydeath/ffxi-addons;mousseng/xitools
+posfind,Posfind,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,4,3.71,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons
+statsearch,Statsearch,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,4,3.71,Icydeath/ffxi-addons;lili-ffxi/FFXI-Addons
+superwarp,Superwarp,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,travel_navigation,2,69,4,3.71,AkadenTK/superwarp;Icydeath/ffxi-addons
+smarttarget,Smarttarget,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,combat_automation,2,69,5,3.43,Icydeath/ffxi-addons;Phayde/Windower-addons
+ambuloot,Ambuloot,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,economy_inventory,1,69,1,3.43,Icydeath/ffxi-addons
+ase,Ase,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+attackid,Attackid,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+attackwithme,Attackwithme,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+autochain,Autochain,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,1,69,1,3.43,Icydeath/ffxi-addons
+autoinvite,Autoinvite,FFXI Windower Addons,https://github.com/Lygre/addons,medium,automation,1,18,1,3.43,Lygre/addons
+autopup,Autopup,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,1,69,1,3.43,Icydeath/ffxi-addons
+autoraise,Autoraise,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,1,69,1,3.43,Icydeath/ffxi-addons
+autoskillchain,Autoskillchain,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,1,69,1,3.43,Icydeath/ffxi-addons
+autounm,Autounm,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,1,69,1,3.43,Icydeath/ffxi-addons
+autovw,Autovw,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,1,69,1,3.43,Icydeath/ffxi-addons
+autowatch,Autowatch,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,1,69,1,3.43,Icydeath/ffxi-addons
+barfiller,Barfiller,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,ui_gear,1,17,1,3.43,mverteuil/windower4-addons
+blist,Blist,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+broseem,Broseem,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+canteen,Canteen,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+capetrader,Capetrader,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,economy_inventory,1,69,1,3.43,Icydeath/ffxi-addons
+charmed,Charmed,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+chars,Chars,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+chatlink,Chatlink,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+checkparam,Checkparam,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+crb_addon,Crb Addon,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+cureplease_addon,Cureplease Addon,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+currencies,Currencies,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+distanceplus,Distanceplus,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+drop,Drop,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+enemybar,Enemybar,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,ui_gear,1,17,1,3.43,mverteuil/windower4-addons
+enemybar2,Enemybar2,Evolution of the simpler Windower addon that displays a target health bar prominently onscreen,https://github.com/AkadenTK/enemybar2,medium,ui_gear,1,19,1,3.43,AkadenTK/enemybar2
+eschachest,Eschachest,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+export_items,Export Items,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,economy_inventory,1,69,1,3.43,Icydeath/ffxi-addons
+ffxicaddieprovider,FFXIcaddieprovider,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+ffxikeys,FFXIkeys,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+finalalert,Finalalert,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+followme,Followme,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+giltracker,Giltracker,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+highlight,Highlight,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+impalert,Impalert,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+inforeplacer,Inforeplacer,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+jobchange,Jobchange,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+lazy,Lazy,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+locke,Locke,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+lockpick,Lockpick,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+maga,Maga,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+masstrade,Masstrade,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,economy_inventory,1,69,1,3.43,Icydeath/ffxi-addons
+moveitems,Moveitems,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,economy_inventory,1,69,1,3.43,Icydeath/ffxi-addons
+myhome,Myhome,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+myomen,Myomen,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+nnitimer,Nnitimer,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,diagnostics,1,69,1,3.43,Icydeath/ffxi-addons
+noknock,Noknock,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+nostrum,Nostrum,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+ohshi,Ohshi,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+oneoffs,Oneoffs,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+partypets,Partypets,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,ui_gear,1,69,1,3.43,Icydeath/ffxi-addons
+pet_fix,Pet Fix,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+petparty,Petparty,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,ui_gear,1,69,1,3.43,Icydeath/ffxi-addons
+plasmon,Plasmon,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+plugin_manager,Plugin Manager,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+positions,Positions,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+reive,Reive,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+repeater,Repeater,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+rhombus,Rhombus,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+roe,Roe,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+rollbot,Rollbot,FFXI Windower Addons,https://github.com/Lygre/addons,medium,automation,1,18,1,3.43,Lygre/addons
+rolldistance,Rolldistance,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+rtfm,Rtfm,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+runicportal,Runicportal,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+salvage2,Salvage2,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+satacast,Satacast,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+schskillchain,Schskillchain,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,combat_automation,1,69,1,3.43,Icydeath/ffxi-addons
+scriptedextender,Scriptedextender,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+sendalltarget,Sendalltarget,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,combat_automation,1,69,1,3.43,Icydeath/ffxi-addons
+setbgm,Setbgm,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+settarget,Settarget,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,combat_automation,1,69,1,3.43,Icydeath/ffxi-addons
+simpleassist,Simpleassist,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,1,69,1,3.43,Icydeath/ffxi-addons
+sirpopalot,Sirpopalot,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+skilluptracker,Skilluptracker,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+spellspammer,Spellspammer,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+stars,Stars,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+stna,Stna,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+stopwatch,Stopwatch,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+strathelper,Strathelper,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,automation,1,17,1,3.43,mverteuil/windower4-addons
+synergy,Synergy,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+taps,Taps,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+targeter,Targeter,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,combat_automation,1,69,1,3.43,Icydeath/ffxi-addons
+targetinfo,Targetinfo,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,combat_automation,1,17,1,3.43,mverteuil/windower4-addons
+targetinfoex,Targetinfoex,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,combat_automation,1,69,1,3.43,Icydeath/ffxi-addons
+targetplus,Targetplus,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,combat_automation,1,69,1,3.43,Icydeath/ffxi-addons
+text,Text,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+thfknife,Thfknife,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+tonic,Tonic,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+trader,Trader,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,economy_inventory,1,69,1,3.43,Icydeath/ffxi-addons
+translate,Translate,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,1,18,1,3.43,Lygre/addons
+triggers,Triggers,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+truesight,Truesight,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+valkyrie,Valkyrie,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+visiblefavor,Visiblefavor,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+voidwalker,Voidwalker,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+voidwatch,Voidwatch,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+vwpop,Vwpop,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+warpmenu,Warpmenu,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,travel_navigation,1,69,1,3.43,Icydeath/ffxi-addons
+where,Where,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+widescantool,Widescantool,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+woehelper,Woehelper,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,1,69,1,3.43,Icydeath/ffxi-addons
+xivcrossbar,XIvcrossbar,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,ui_gear,1,69,1,3.43,Icydeath/ffxi-addons
+xivhotbar,XIvhotbar,,,low,ui_gear,1,18,1,3.43,Akirane/XIVHotbar
+yush,Yush,FFXI Windower 4 Addons,https://github.com/mverteuil/windower4-addons,medium,general_qol,1,17,1,3.43,mverteuil/windower4-addons
+zenimonsnap,Zenimonsnap,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,1,69,1,3.43,Icydeath/ffxi-addons
+zonename,Zonename,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,travel_navigation,1,69,1,3.43,Icydeath/ffxi-addons
+skillchain,Skillchain,Some addons and plugins for FFXI (Ashita),https://github.com/mousseng/xitools,medium,combat_automation,3,29,4,3.26,Lygre/addons;mousseng/xitools;mverteuil/windower4-addons
+allseeingeye,Allseeingeye,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium,general_qol,2,99,1,2.66,Icydeath/ffxi-addons;ProjectTako/ffxi-addons
+autocor,Autocor,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,automation,2,79,1,2.66,Icydeath/ffxi-addons;Ivaar/Windower-addons
+autogeo,Autogeo,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,automation,2,79,1,2.66,Icydeath/ffxi-addons;Ivaar/Windower-addons
+chatman,Chatman,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,general_qol,2,79,1,2.66,Icydeath/ffxi-addons;Ivaar/Windower-addons
+equipviewer,Equipviewer,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium,automation,2,99,1,2.66,Icydeath/ffxi-addons;ProjectTako/ffxi-addons
+htmb,Htmb,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,general_qol,2,79,1,2.66,Icydeath/ffxi-addons;Ivaar/Windower-addons
+magicassistant,Magicassistant,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,2,69,1,2.66,Icydeath/ffxi-addons;ValokAsura/WindowerAddons
+parse,Parse,FFXI Windower Addons,https://github.com/Lygre/addons,medium,diagnostics,2,18,1,2.66,Lygre/addons;flippant/parse
+partybuffs,Partybuffs,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium,automation,2,99,1,2.66,Lygre/addons;ProjectTako/ffxi-addons
+porterpacker,Porterpacker,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,economy_inventory,2,79,1,2.66,Icydeath/ffxi-addons;Ivaar/Windower-addons
+quicktrade,Quicktrade,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,ui_gear,2,69,1,2.66,Icydeath/ffxi-addons;ValokAsura/WindowerAddons
+react,React,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,medium,automation,2,99,1,2.66,Icydeath/ffxi-addons;ProjectTako/ffxi-addons
+sendtarget,Sendtarget,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,combat_automation,2,69,1,2.66,DiscipleOfEris/Windower4Addons;Icydeath/ffxi-addons
+singer,Singer,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,general_qol,2,79,1,2.66,Icydeath/ffxi-addons;Ivaar/Windower-addons
+tradenpc,Tradenpc,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,economy_inventory,2,79,1,2.66,Icydeath/ffxi-addons;Ivaar/Windower-addons
+anchor,Anchor,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+autocontrol,Autocontrol,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+autojoin,Autojoin,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+autosynth,Autosynth,FFXI Windower Addons,https://github.com/Lygre/addons,medium,automation,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+autows,Autows,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+azuresets,Azuresets,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+bluguide,Bluguide,FFXI Windower Addons,https://github.com/Lygre/addons,medium,travel_navigation,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+boxdestroyer,Boxdestroyer,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+clock,Clock,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+debuffed,Debuffed,FFXI Windower Addons,https://github.com/Lygre/addons,medium,combat_automation,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+digger,Digger,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+distance,Distance,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+dostuff,Dostuff,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+dynamishelper,Dynamishelper,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,2,69,1,2.31,Icydeath/ffxi-addons;mverteuil/windower4-addons
+fisher,Fisher,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;mverteuil/windower4-addons
+gametime,Gametime,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+instals,Instals,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+latentchecker,Latentchecker,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+linker,Linker,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+lottery,Lottery,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+macrochanger,Macrochanger,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;mverteuil/windower4-addons
+ohnoyoudont,Ohnoyoudont,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+opensesame,Opensesame,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+packetviewer,Packetviewer,FFXI Windower Addons,https://github.com/Lygre/addons,medium,diagnostics,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+pettp,Pettp,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+porter,Porter,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,economy_inventory,2,69,1,2.31,Icydeath/ffxi-addons;mverteuil/windower4-addons
+pricer,Pricer,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+rolltracker,Rolltracker,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+scoreboard,Scoreboard,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+send,Send,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+silence,Silence,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;mverteuil/windower4-addons
+speedchecker,Speedchecker,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+spellcheck,Spellcheck,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+sprint,Sprint,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+subtarget,Subtarget,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,combat_automation,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+synthall,Synthall,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+thtracker,Thtracker,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;mverteuil/windower4-addons
+timestamp,Timestamp,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+treasurepool,Treasurepool,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,2,69,1,2.31,Icydeath/ffxi-addons;Lygre/addons
+update,Update,FFXI Windower Addons,https://github.com/Lygre/addons,medium,general_qol,2,18,1,2.31,Lygre/addons;mverteuil/windower4-addons
+skillchains,Skillchains,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low,combat_automation,4,69,1,2.27,Icydeath/ffxi-addons;Ivaar/Skillchains;Lygre/addons;mverteuil/windower4-addons
+auctionhelper,Auctionhelper,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,automation,3,79,1,2.21,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons
+trade,Trade,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,medium,economy_inventory,3,79,1,2.21,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons
+fastcs,Fastcs,Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3,https://github.com/ProjectTako/ffxi-addons,low,general_qol,4,99,1,1.92,Icydeath/ffxi-addons;Lygre/addons;ProjectTako/ffxi-addons;mverteuil/windower4-addons
+sellnpc,Sellnpc,FFXI Windower addons,https://github.com/Ivaar/Windower-addons,low,economy_inventory,4,79,1,1.92,Icydeath/ffxi-addons;Ivaar/Windower-addons;Lygre/addons;mverteuil/windower4-addons
+aecho,Aecho,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+autora,Autora,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,automation,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+battlemod,Battlemod,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+cancel,Cancel,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+consolebg,Consolebg,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+dressup,Dressup,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+enternity,Enternity,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+eval,Eval,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+findall,Findall,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+gearswap,Gearswap,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,ui_gear,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+invspace,Invspace,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,economy_inventory,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+itemizer,Itemizer,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,economy_inventory,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+logger,Logger,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,diagnostics,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+organizer,Organizer,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+pointwatch,Pointwatch,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+pouches,Pouches,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+shortcuts,Shortcuts,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+sparks,Sparks,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+tparty,Tparty,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,ui_gear,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+treasury,Treasury,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,general_qol,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+zonetimer,Zonetimer,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,medium,travel_navigation,3,69,1,1.86,Icydeath/ffxi-addons;Lygre/addons;mverteuil/windower4-addons
+healbot,Healbot,FFXI Windower Addons,https://github.com/Icydeath/ffxi-addons,low,automation,4,69,1,1.57,Icydeath/ffxi-addons;Lygre/addons;lorand-ffxi/HealBot;mverteuil/windower4-addons

--- a/ffxi-addon-catalog-normalized.json
+++ b/ffxi-addon-catalog-normalized.json
@@ -859,11 +859,12 @@
     "addon_name": "Readycheck",
     "category": "general_qol",
     "repos": [
+      "Lydya-nick77/readycheck",
       "iLVL-Key/FFXI"
     ],
-    "repo_count": 1,
+    "repo_count": 2,
     "best_repo_stars": 22,
-    "freshness_max": 5,
+    "freshness_max": 1,
     "opportunity_score": 4.83,
     "description": "Various FFXI projects",
     "description_source": "https://github.com/iLVL-Key/FFXI",
@@ -2321,11 +2322,12 @@
     "addon_name": "Smarttarget",
     "category": "combat_automation",
     "repos": [
-      "Icydeath/ffxi-addons"
+      "Icydeath/ffxi-addons",
+      "Phayde/Windower-addons"
     ],
-    "repo_count": 1,
+    "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 1,
+    "freshness_max": 8,
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -4545,5 +4547,200 @@
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "low"
+  },
+  {
+    "addon_key": "digskill",
+    "addon_name": "Digskill",
+    "category": "general_qol",
+    "repos": [
+      "Phayde/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 8,
+    "opportunity_score": 4.2,
+    "description": "A collection of addons for FFXI Windower",
+    "description_source": "https://github.com/Phayde/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trashit",
+    "addon_name": "Trashit",
+    "category": "general_qol",
+    "repos": [
+      "Phayde/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 8,
+    "opportunity_score": 4.2,
+    "description": "A collection of addons for FFXI Windower",
+    "description_source": "https://github.com/Phayde/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanaclock",
+    "addon_name": "Vanaclock",
+    "category": "general_qol",
+    "repos": [
+      "BagTown/vanaclock"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 25,
+    "opportunity_score": 4.2,
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "description_source": "https://github.com/BagTown/vanaclock",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanatime",
+    "addon_name": "Vanatime",
+    "category": "general_qol",
+    "repos": [
+      "BagTown/vanaclock"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 25,
+    "opportunity_score": 4.2,
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "description_source": "https://github.com/BagTown/vanaclock",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fasttarget",
+    "addon_name": "Fasttarget",
+    "category": "general_qol",
+    "repos": [
+      "LordAttilas/FastTarget"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 6,
+    "opportunity_score": 4.2,
+    "description": "Windower 4 addon for FFXI that allow quicker target change",
+    "description_source": "https://github.com/LordAttilas/FastTarget",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fancytrusts",
+    "addon_name": "Fancytrusts",
+    "category": "general_qol",
+    "repos": [
+      "ariel-logos/FancyTrusts"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 5,
+    "freshness_max": 14,
+    "opportunity_score": 4.2,
+    "description": "A fancy UI to manage trusts",
+    "description_source": "https://github.com/ariel-logos/FancyTrusts",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "closetcleaner2",
+    "addon_name": "Closetcleaner2",
+    "category": "general_qol",
+    "repos": [
+      "Gol-exe/closetCleaner2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 0,
+    "opportunity_score": 4.2,
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "description_source": "https://github.com/Gol-exe/closetCleaner2",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "luaparser",
+    "addon_name": "Luaparser",
+    "category": "general_qol",
+    "repos": [
+      "Gol-exe/closetCleaner2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 0,
+    "opportunity_score": 4.2,
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "description_source": "https://github.com/Gol-exe/closetCleaner2",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "weeklier",
+    "addon_name": "Weeklier",
+    "category": "general_qol",
+    "repos": [
+      "patheed-ffxi/weeklier"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.",
+    "description_source": "https://github.com/patheed-ffxi/weeklier",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "mogchat",
+    "addon_name": "Mogchat",
+    "category": "general_qol",
+    "repos": [
+      "glitchv0/mogchat"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 1,
+    "opportunity_score": 4.2,
+    "description": "AIM/ICQ style FFXI chat addon",
+    "description_source": "https://github.com/glitchv0/mogchat",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dpsmeter",
+    "addon_name": "Dpsmeter",
+    "category": "general_qol",
+    "repos": [
+      "cybersoulwing/dpsmeter"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 12,
+    "opportunity_score": 4.2,
+    "description": "FFXI Windower addon",
+    "description_source": "https://github.com/cybersoulwing/dpsmeter",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "automining",
+    "addon_name": "Automining",
+    "category": "general_qol",
+    "repos": [
+      "cybersoulwing/AutoMining"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 14,
+    "opportunity_score": 4.2,
+    "description": "FFXI Windower addon",
+    "description_source": "https://github.com/cybersoulwing/AutoMining",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "packrat",
+    "addon_name": "Packrat",
+    "category": "general_qol",
+    "repos": [
+      "Mr-Sithel/packrat"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 29,
+    "opportunity_score": 4.2,
+    "description": "FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",
+    "description_source": "https://github.com/Mr-Sithel/packrat",
+    "description_confidence": "medium"
   }
 ]

--- a/ffxi-addon-catalog-normalized.json
+++ b/ffxi-addon-catalog-normalized.json
@@ -1,47 +1,33 @@
 [
   {
-    "addon_key": "xipivot",
-    "addon_name": "XIpivot",
+    "addon_key": "readycheck",
+    "addon_name": "Readycheck",
     "category": "general_qol",
     "repos": [
-      "HealsCodes/XIPivot"
+      "Lydya-nick77/readycheck",
+      "iLVL-Key/FFXI"
     ],
-    "repo_count": 1,
-    "best_repo_stars": 61,
+    "repo_count": 2,
+    "best_repo_stars": 22,
     "freshness_max": 5,
     "opportunity_score": 4.83,
-    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
-    "description_source": "https://github.com/HealsCodes/XIPivot",
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "trust",
-    "addon_name": "Trust",
-    "category": "automation",
+    "addon_key": "addons",
+    "addon_name": "Addons",
+    "category": "diagnostics",
     "repos": [
-      "cyritegamestudios/trust"
+      "HealsCodes/statustimers"
     ],
     "repo_count": 1,
-    "best_repo_stars": 49,
-    "freshness_max": 5,
+    "best_repo_stars": 15,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
-    "description": "Windower 4 addon for FFXI to automate your character in battle.",
-    "description_source": "https://github.com/cyritegamestudios/trust",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xivparty",
-    "addon_name": "XIvparty",
-    "category": "ui_gear",
-    "repos": [
-      "Tylas11/XivParty"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 47,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "A party list addon for Windower 4.",
-    "description_source": "https://github.com/Tylas11/XivParty",
+    "description": "Statustimers for Ashita v4",
+    "description_source": "https://github.com/HealsCodes/statustimers",
     "description_confidence": "medium"
   },
   {
@@ -53,625 +39,10 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 35,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
     "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
     "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "augments",
-    "addon_name": "Augments",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chatfix",
-    "addon_name": "Chatfix",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "clevel",
-    "addon_name": "Clevel",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "collector",
-    "addon_name": "Collector",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dramagen",
-    "addon_name": "Dramagen",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "gilbox",
-    "addon_name": "Gilbox",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "indinope",
-    "addon_name": "Indinope",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "jobinit",
-    "addon_name": "Jobinit",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "kaomoji",
-    "addon_name": "Kaomoji",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "menufix",
-    "addon_name": "Menufix",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "mousehalo",
-    "addon_name": "Mousehalo",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ondemand",
-    "addon_name": "Ondemand",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "position_manager",
-    "addon_name": "Position Manager",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "readable",
-    "addon_name": "Readable",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "safeoboro",
-    "addon_name": "Safeoboro",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "silttracker",
-    "addon_name": "Silttracker",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "smeagol",
-    "addon_name": "Smeagol",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "special",
-    "addon_name": "Special",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tellapart",
-    "addon_name": "Tellapart",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tellfix",
-    "addon_name": "Tellfix",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tiptoes",
-    "addon_name": "Tiptoes",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tpsreport",
-    "addon_name": "Tpsreport",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "trialtracker",
-    "addon_name": "Trialtracker",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "useall",
-    "addon_name": "Useall",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "waveback",
-    "addon_name": "Waveback",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "weathermon",
-    "addon_name": "Weathermon",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "witnessprotection",
-    "addon_name": "Witnessprotection",
-    "category": "general_qol",
-    "repos": [
-      "lili-ffxi/FFXI-Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 35,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
-    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "bluspells",
-    "addon_name": "Bluspells",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chatty",
-    "addon_name": "Chatty",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "colure",
-    "addon_name": "Colure",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dxui",
-    "addon_name": "Dxui",
-    "category": "ui_gear",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "imrecast",
-    "addon_name": "Imrecast",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "loggers",
-    "addon_name": "Loggers",
-    "category": "diagnostics",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "minimap-helper",
-    "addon_name": "Minimap Helper",
-    "category": "automation",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "rcheck",
-    "addon_name": "Rcheck",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "relicge",
-    "addon_name": "Relicge",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "repl",
-    "addon_name": "Repl",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "strats",
-    "addon_name": "Strats",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "trials",
-    "addon_name": "Trials",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "wheel",
-    "addon_name": "Wheel",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xitools",
-    "addon_name": "XItools",
-    "category": "general_qol",
-    "repos": [
-      "mousseng/xitools"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 29,
-    "freshness_max": 5,
-    "opportunity_score": 4.83,
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "description_source": "https://github.com/mousseng/xitools",
     "description_confidence": "medium"
   },
   {
@@ -687,6 +58,21 @@
     "opportunity_score": 4.83,
     "description": "Various FFXI projects",
     "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "augments",
+    "addon_name": "Augments",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
     "description_confidence": "medium"
   },
   {
@@ -720,6 +106,21 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "bluspells",
+    "addon_name": "Bluspells",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "callouts",
     "addon_name": "Callouts",
     "category": "general_qol",
@@ -732,6 +133,111 @@
     "opportunity_score": 4.83,
     "description": "Various FFXI projects",
     "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatfix",
+    "addon_name": "Chatfix",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatty",
+    "addon_name": "Chatty",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "clevel",
+    "addon_name": "Clevel",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "collector",
+    "addon_name": "Collector",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "colure",
+    "addon_name": "Colure",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dramagen",
+    "addon_name": "Dramagen",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dxui",
+    "addon_name": "Dxui",
+    "category": "ui_gear",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
     "description_confidence": "medium"
   },
   {
@@ -765,6 +271,21 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "ffxi-zonename",
+    "addon_name": "FFXI Zonename",
+    "category": "travel_navigation",
+    "repos": [
+      "onimitch/ffxi-zonename"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 4,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.",
+    "description_source": "https://github.com/onimitch/ffxi-zonename",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "gaolplan",
     "addon_name": "Gaolplan",
     "category": "automation",
@@ -780,6 +301,36 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "gilbox",
+    "addon_name": "Gilbox",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "gmtools",
+    "addon_name": "Gmtools",
+    "category": "automation",
+    "repos": [
+      "SQLCommit/GMTools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 2,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - LSB GM Command Helper",
+    "description_source": "https://github.com/SQLCommit/GMTools",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "helper",
     "addon_name": "Helper",
     "category": "automation",
@@ -792,6 +343,36 @@
     "opportunity_score": 4.83,
     "description": "Various FFXI projects",
     "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "imrecast",
+    "addon_name": "Imrecast",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "indinope",
+    "addon_name": "Indinope",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
     "description_confidence": "medium"
   },
   {
@@ -825,6 +406,36 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "jobinit",
+    "addon_name": "Jobinit",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "kaomoji",
+    "addon_name": "Kaomoji",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "leaderboard",
     "addon_name": "Leaderboard",
     "category": "general_qol",
@@ -855,19 +466,258 @@
     "description_confidence": "medium"
   },
   {
-    "addon_key": "readycheck",
-    "addon_name": "Readycheck",
+    "addon_key": "loggers",
+    "addon_name": "Loggers",
+    "category": "diagnostics",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "lootscope",
+    "addon_name": "Lootscope",
+    "category": "economy_inventory",
+    "repos": [
+      "SQLCommit/LootScope"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 2,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - Loot Drop Tracker",
+    "description_source": "https://github.com/SQLCommit/LootScope",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "memscope",
+    "addon_name": "Memscope",
+    "category": "diagnostics",
+    "repos": [
+      "SQLCommit/MemScope"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 2,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage",
+    "description_source": "https://github.com/SQLCommit/MemScope",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "menufix",
+    "addon_name": "Menufix",
     "category": "general_qol",
     "repos": [
-      "Lydya-nick77/readycheck",
-      "iLVL-Key/FFXI"
+      "lili-ffxi/FFXI-Addons"
     ],
-    "repo_count": 2,
-    "best_repo_stars": 22,
-    "freshness_max": 1,
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "minimap-helper",
+    "addon_name": "Minimap Helper",
+    "category": "automation",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "mousehalo",
+    "addon_name": "Mousehalo",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ondemand",
+    "addon_name": "Ondemand",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "position_manager",
+    "addon_name": "Position Manager",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "rcheck",
+    "addon_name": "Rcheck",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "readable",
+    "addon_name": "Readable",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "relicge",
+    "addon_name": "Relicge",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "repl",
+    "addon_name": "Repl",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "safeoboro",
+    "addon_name": "Safeoboro",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "silttracker",
+    "addon_name": "Silttracker",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "smeagol",
+    "addon_name": "Smeagol",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "special",
+    "addon_name": "Special",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "strats",
+    "addon_name": "Strats",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
     "description_confidence": "medium"
   },
   {
@@ -898,6 +748,141 @@
     "opportunity_score": 4.83,
     "description": "Various FFXI projects",
     "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tellapart",
+    "addon_name": "Tellapart",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tellfix",
+    "addon_name": "Tellfix",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tiptoes",
+    "addon_name": "Tiptoes",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tourist",
+    "addon_name": "Tourist",
+    "category": "travel_navigation",
+    "repos": [
+      "Bryenne-Sylph/tourist"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
+    "description_source": "https://github.com/Bryenne-Sylph/tourist",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tpsreport",
+    "addon_name": "Tpsreport",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trials",
+    "addon_name": "Trials",
+    "category": "general_qol",
+    "repos": [
+      "mousseng/xitools"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trialtracker",
+    "addon_name": "Trialtracker",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trust",
+    "addon_name": "Trust",
+    "category": "automation",
+    "repos": [
+      "cyritegamestudios/trust"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 49,
+    "freshness_max": 5,
+    "opportunity_score": 4.83,
+    "description": "Windower 4 addon for FFXI to automate your character in battle.",
+    "description_source": "https://github.com/cyritegamestudios/trust",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "useall",
+    "addon_name": "Useall",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
     "description_confidence": "medium"
   },
   {
@@ -946,48 +931,63 @@
     "description_confidence": "medium"
   },
   {
-    "addon_key": "znmtracker",
-    "addon_name": "Znmtracker",
+    "addon_key": "waveback",
+    "addon_name": "Waveback",
     "category": "general_qol",
     "repos": [
-      "iLVL-Key/FFXI"
+      "lili-ffxi/FFXI-Addons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 22,
-    "freshness_max": 5,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
-    "description": "Various FFXI projects",
-    "description_source": "https://github.com/iLVL-Key/FFXI",
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "addons",
-    "addon_name": "Addons",
-    "category": "diagnostics",
+    "addon_key": "weathermon",
+    "addon_name": "Weathermon",
+    "category": "general_qol",
     "repos": [
-      "HealsCodes/statustimers"
+      "lili-ffxi/FFXI-Addons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 15,
-    "freshness_max": 5,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
-    "description": "Statustimers for Ashita v4",
-    "description_source": "https://github.com/HealsCodes/statustimers",
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "ffxi-zonename",
-    "addon_name": "FFXI Zonename",
-    "category": "travel_navigation",
+    "addon_key": "wheel",
+    "addon_name": "Wheel",
+    "category": "general_qol",
     "repos": [
-      "onimitch/ffxi-zonename"
+      "mousseng/xitools"
     ],
     "repo_count": 1,
-    "best_repo_stars": 4,
-    "freshness_max": 5,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
-    "description": "This addon for Ashita v4 displays the zone and region name for a short time while changing zones. This is a port of the Windower Zonename addon.",
-    "description_source": "https://github.com/onimitch/ffxi-zonename",
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "witnessprotection",
+    "addon_name": "Witnessprotection",
+    "category": "general_qol",
+    "repos": [
+      "lili-ffxi/FFXI-Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 35,
+    "freshness_max": 4,
+    "opportunity_score": 4.83,
+    "description": "Addons I wrote for Final Fantasy XI. Compatible with Windower.",
+    "description_source": "https://github.com/lili-ffxi/FFXI-Addons",
     "description_confidence": "medium"
   },
   {
@@ -1006,63 +1006,63 @@
     "description_confidence": "medium"
   },
   {
-    "addon_key": "tourist",
-    "addon_name": "Tourist",
-    "category": "travel_navigation",
+    "addon_key": "xipivot",
+    "addon_name": "XIpivot",
+    "category": "general_qol",
     "repos": [
-      "Bryenne-Sylph/tourist"
+      "HealsCodes/XIPivot"
     ],
     "repo_count": 1,
-    "best_repo_stars": 3,
-    "freshness_max": 5,
+    "best_repo_stars": 61,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
-    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
-    "description_source": "https://github.com/Bryenne-Sylph/tourist",
+    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
+    "description_source": "https://github.com/HealsCodes/XIPivot",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "gmtools",
-    "addon_name": "Gmtools",
-    "category": "automation",
+    "addon_key": "xitools",
+    "addon_name": "XItools",
+    "category": "general_qol",
     "repos": [
-      "SQLCommit/GMTools"
+      "mousseng/xitools"
     ],
     "repo_count": 1,
-    "best_repo_stars": 2,
-    "freshness_max": 5,
+    "best_repo_stars": 29,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
-    "description": "FFXI - Ashita v4.3 Addon - LSB GM Command Helper",
-    "description_source": "https://github.com/SQLCommit/GMTools",
+    "description": "Some addons and plugins for FFXI (Ashita)",
+    "description_source": "https://github.com/mousseng/xitools",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "lootscope",
-    "addon_name": "Lootscope",
-    "category": "economy_inventory",
+    "addon_key": "xivparty",
+    "addon_name": "XIvparty",
+    "category": "ui_gear",
     "repos": [
-      "SQLCommit/LootScope"
+      "Tylas11/XivParty"
     ],
     "repo_count": 1,
-    "best_repo_stars": 2,
-    "freshness_max": 5,
+    "best_repo_stars": 47,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
-    "description": "FFXI - Ashita v4.3 Addon - Loot Drop Tracker",
-    "description_source": "https://github.com/SQLCommit/LootScope",
+    "description": "A party list addon for Windower 4.",
+    "description_source": "https://github.com/Tylas11/XivParty",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "memscope",
-    "addon_name": "Memscope",
-    "category": "diagnostics",
+    "addon_key": "znmtracker",
+    "addon_name": "Znmtracker",
+    "category": "general_qol",
     "repos": [
-      "SQLCommit/MemScope"
+      "iLVL-Key/FFXI"
     ],
     "repo_count": 1,
-    "best_repo_stars": 2,
+    "best_repo_stars": 22,
     "freshness_max": 5,
     "opportunity_score": 4.83,
-    "description": "FFXI - Ashita v4.3 Addon - Monitors Addon Memory Usage",
-    "description_source": "https://github.com/SQLCommit/MemScope",
+    "description": "Various FFXI projects",
+    "description_source": "https://github.com/iLVL-Key/FFXI",
     "description_confidence": "medium"
   },
   {
@@ -1074,70 +1074,325 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 2,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 4.83,
     "description": "FFXI - Ashita v4.3 Addon - Zone Line Visualizer",
     "description_source": "https://github.com/SQLCommit/ZoneLines",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "debuff-tracker",
-    "addon_name": "Debuff Tracker",
-    "category": "automation",
+    "addon_key": "automining",
+    "addon_name": "Automining",
+    "category": "general_qol",
     "repos": [
-      "ProjectTako/ffxi-addons"
+      "cybersoulwing/AutoMining"
     ],
     "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "FFXI Windower addon",
+    "description_source": "https://github.com/cybersoulwing/AutoMining",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "menus",
-    "addon_name": "Menus",
-    "category": "automation",
+    "addon_key": "closetcleaner2",
+    "addon_name": "Closetcleaner2",
+    "category": "general_qol",
     "repos": [
-      "ProjectTako/ffxi-addons"
+      "Gol-exe/closetCleaner2"
     ],
     "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "description_source": "https://github.com/Gol-exe/closetCleaner2",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "scanzone",
-    "addon_name": "Scanzone",
-    "category": "travel_navigation",
+    "addon_key": "digskill",
+    "addon_name": "Digskill",
+    "category": "general_qol",
     "repos": [
-      "ProjectTako/ffxi-addons"
+      "Phayde/Windower-addons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "best_repo_stars": 1,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "A collection of addons for FFXI Windower",
+    "description_source": "https://github.com/Phayde/Windower-addons",
     "description_confidence": "medium"
   },
   {
-    "addon_key": "turnaround",
-    "addon_name": "Turnaround",
-    "category": "automation",
+    "addon_key": "dpsmeter",
+    "addon_name": "Dpsmeter",
+    "category": "general_qol",
     "repos": [
-      "ProjectTako/ffxi-addons"
+      "cybersoulwing/dpsmeter"
     ],
     "repo_count": 1,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "FFXI Windower addon",
+    "description_source": "https://github.com/cybersoulwing/dpsmeter",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fancytrusts",
+    "addon_name": "Fancytrusts",
+    "category": "general_qol",
+    "repos": [
+      "ariel-logos/FancyTrusts"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 5,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "A fancy UI to manage trusts",
+    "description_source": "https://github.com/ariel-logos/FancyTrusts",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fasttarget",
+    "addon_name": "Fasttarget",
+    "category": "general_qol",
+    "repos": [
+      "LordAttilas/FastTarget"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Windower 4 addon for FFXI that allow quicker target change",
+    "description_source": "https://github.com/LordAttilas/FastTarget",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "luaparser",
+    "addon_name": "Luaparser",
+    "category": "general_qol",
+    "repos": [
+      "Gol-exe/closetCleaner2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "description_source": "https://github.com/Gol-exe/closetCleaner2",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "mogchat",
+    "addon_name": "Mogchat",
+    "category": "general_qol",
+    "repos": [
+      "glitchv0/mogchat"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "AIM/ICQ style FFXI chat addon",
+    "description_source": "https://github.com/glitchv0/mogchat",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "packrat",
+    "addon_name": "Packrat",
+    "category": "general_qol",
+    "repos": [
+      "Mr-Sithel/packrat"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",
+    "description_source": "https://github.com/Mr-Sithel/packrat",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "trashit",
+    "addon_name": "Trashit",
+    "category": "general_qol",
+    "repos": [
+      "Phayde/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "A collection of addons for FFXI Windower",
+    "description_source": "https://github.com/Phayde/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanaclock",
+    "addon_name": "Vanaclock",
+    "category": "general_qol",
+    "repos": [
+      "BagTown/vanaclock"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "description_source": "https://github.com/BagTown/vanaclock",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "vanatime",
+    "addon_name": "Vanatime",
+    "category": "general_qol",
+    "repos": [
+      "BagTown/vanaclock"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "description_source": "https://github.com/BagTown/vanaclock",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "weeklier",
+    "addon_name": "Weeklier",
+    "category": "general_qol",
+    "repos": [
+      "patheed-ffxi/weeklier"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 5,
+    "opportunity_score": 4.2,
+    "description": "An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.",
+    "description_source": "https://github.com/patheed-ffxi/weeklier",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "automb",
+    "addon_name": "autoMB",
+    "category": "combat_automation",
+    "repos": [
+      "ekrividus/autoMB"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 7,
+    "freshness_max": 1,
+    "opportunity_score": 4.0,
+    "description": "An ffxi windower addon to help with magic bursts",
+    "description_source": "https://github.com/ekrividus/autoMB",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "magianws",
+    "addon_name": "magianws",
+    "category": "combat_automation",
+    "repos": [
+      "rouzazari/magianws"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 4,
+    "opportunity_score": 4.0,
+    "description": "FFXI Windower addon that assists with Magian Weapon Skill Trials",
+    "description_source": "https://github.com/rouzazari/magianws",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "moblevel",
+    "addon_name": "MobLevel",
+    "category": "ui_gear",
+    "repos": [
+      "DiscipleOfEris/MobLevel"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 3,
+    "freshness_max": 1,
+    "opportunity_score": 4.0,
+    "description": "FFXI Windower addon that displays the level of the selected mob in their target box.",
+    "description_source": "https://github.com/DiscipleOfEris/MobLevel",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "mogmover",
+    "addon_name": "MogMover",
+    "category": "economy_inventory",
+    "repos": [
+      "djlabbe/MogMover"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 0,
+    "freshness_max": 4,
+    "opportunity_score": 4.0,
+    "description": "FFXI / Windower Addon - Automated Inventory Management",
+    "description_source": "https://github.com/djlabbe/MogMover",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "npcinteract",
+    "addon_name": "NpcInteract",
+    "category": "automation",
+    "repos": [
+      "DiscipleOfEris/NpcInteract"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 7,
+    "freshness_max": 1,
+    "opportunity_score": 4.0,
+    "description": "FFXI Windower addon for multiboxers to reduce tedious switching. Allow your alts to copy your main's NPC interactions.",
+    "description_source": "https://github.com/DiscipleOfEris/NpcInteract",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "stats",
+    "addon_name": "Stats",
+    "category": "diagnostics",
+    "repos": [
+      "garyfromwork/Stats"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 1,
+    "freshness_max": 4,
+    "opportunity_score": 4.0,
+    "description": "FFXI Windower Addon for tracking stats in game such as accuracy rate, min/max damage, spell debuff accuracy, ect.",
+    "description_source": "https://github.com/garyfromwork/Stats",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "assist",
+    "addon_name": "Assist",
+    "category": "automation",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 12,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autoassist",
+    "addon_name": "Autoassist",
+    "category": "automation",
+    "repos": [
+      "ekrividus/autoAssist"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 13,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "An ffxi windower addon to automatically assist a party member in combat",
+    "description_source": "https://github.com/ekrividus/autoAssist",
     "description_confidence": "medium"
   },
   {
@@ -1149,70 +1404,10 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 79,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "FFXI Windower addons",
     "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chococard",
-    "addon_name": "Chococard",
-    "category": "general_qol",
-    "repos": [
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "questlog",
-    "addon_name": "Questlog",
-    "category": "general_qol",
-    "repos": [
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "packetviewerlogviewer",
-    "addon_name": "Packetviewerlogviewer",
-    "category": "diagnostics",
-    "repos": [
-      "ZeromusXYZ/PacketViewerLogViewer"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
-    "description_source": "https://github.com/ZeromusXYZ/PacketViewerLogViewer",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ui",
-    "addon_name": "Ui",
-    "category": "ui_gear",
-    "repos": [
-      "AliekberFFXI/xivcrossbar"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
-    "description_source": "https://github.com/AliekberFFXI/xivcrossbar",
     "description_confidence": "medium"
   },
   {
@@ -1224,11 +1419,26 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 14,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "",
     "description_source": "",
     "description_confidence": "low"
+  },
+  {
+    "addon_key": "chococard",
+    "addon_name": "Chococard",
+    "category": "general_qol",
+    "repos": [
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 79,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
   },
   {
     "addon_key": "crystaltrader",
@@ -1239,70 +1449,25 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 14,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "",
     "description_source": "",
     "description_confidence": "low"
   },
   {
-    "addon_key": "quicktrade_2",
-    "addon_name": "Quicktrade 2",
-    "category": "ui_gear",
-    "repos": [
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 14,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "",
-    "description_source": "",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "autoassist",
-    "addon_name": "Autoassist",
+    "addon_key": "debuff-tracker",
+    "addon_name": "Debuff Tracker",
     "category": "automation",
     "repos": [
-      "ekrividus/autoAssist"
+      "ProjectTako/ffxi-addons"
     ],
     "repo_count": 1,
-    "best_repo_stars": 13,
-    "freshness_max": 2,
+    "best_repo_stars": 99,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
-    "description": "An ffxi windower addon to automatically assist a party member in combat",
-    "description_source": "https://github.com/ekrividus/autoAssist",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xivhotbar2",
-    "addon_name": "XIvhotbar2",
-    "category": "ui_gear",
-    "repos": [
-      "Technyze/XIVHotbar2"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 13,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "",
-    "description_source": "",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "assist",
-    "addon_name": "Assist",
-    "category": "automation",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 12,
-    "freshness_max": 2,
-    "opportunity_score": 3.78,
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
     "description_confidence": "medium"
   },
   {
@@ -1314,7 +1479,7 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 12,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
     "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
@@ -1329,7 +1494,7 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 12,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
     "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
@@ -1344,7 +1509,7 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 12,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
     "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
@@ -1359,7 +1524,7 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 12,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
     "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
@@ -1374,7 +1539,7 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 12,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
     "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
@@ -1389,7 +1554,7 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 12,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
     "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
@@ -1404,7 +1569,7 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 12,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
     "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
@@ -1419,7 +1584,7 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 12,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
     "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
@@ -1434,11 +1599,131 @@
     ],
     "repo_count": 1,
     "best_repo_stars": 12,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 3.78,
     "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
     "description_source": "https://github.com/DiscipleOfEris/Windower4Addons",
     "description_confidence": "medium"
+  },
+  {
+    "addon_key": "menus",
+    "addon_name": "Menus",
+    "category": "automation",
+    "repos": [
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 99,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "packetviewerlogviewer",
+    "addon_name": "Packetviewerlogviewer",
+    "category": "diagnostics",
+    "repos": [
+      "ZeromusXYZ/PacketViewerLogViewer"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
+    "description_source": "https://github.com/ZeromusXYZ/PacketViewerLogViewer",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "questlog",
+    "addon_name": "Questlog",
+    "category": "general_qol",
+    "repos": [
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 79,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "quicktrade_2",
+    "addon_name": "Quicktrade 2",
+    "category": "ui_gear",
+    "repos": [
+      "ValokAsura/WindowerAddons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 14,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "scanzone",
+    "addon_name": "Scanzone",
+    "category": "travel_navigation",
+    "repos": [
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 99,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "turnaround",
+    "addon_name": "Turnaround",
+    "category": "automation",
+    "repos": [
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 99,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ui",
+    "addon_name": "Ui",
+    "category": "ui_gear",
+    "repos": [
+      "AliekberFFXI/xivcrossbar"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
+    "description_source": "https://github.com/AliekberFFXI/xivcrossbar",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "xivhotbar2",
+    "addon_name": "XIvhotbar2",
+    "category": "ui_gear",
+    "repos": [
+      "Technyze/XIVHotbar2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 13,
+    "freshness_max": 1,
+    "opportunity_score": 3.78,
+    "description": "",
+    "description_source": "",
+    "description_confidence": "low"
   },
   {
     "addon_key": "clickfind",
@@ -1450,7 +1735,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 3.71,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -1466,7 +1751,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 3.71,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -1482,7 +1767,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 3.71,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -1498,7 +1783,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 3.71,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -1514,7 +1799,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 3.71,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -1530,7 +1815,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 3.71,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -1546,8 +1831,24 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 3.71,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "smarttarget",
+    "addon_name": "Smarttarget",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Phayde/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 5,
+    "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
@@ -1565,6 +1866,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ase",
+    "addon_name": "Ase",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
     "description_confidence": "medium"
   },
   {
@@ -1610,6 +1926,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "autoinvite",
+    "addon_name": "Autoinvite",
+    "category": "automation",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
     "description_confidence": "medium"
   },
   {
@@ -1703,6 +2034,21 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "barfiller",
+    "addon_name": "Barfiller",
+    "category": "ui_gear",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "blist",
     "addon_name": "Blist",
     "category": "general_qol",
@@ -1715,6 +2061,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "broseem",
+    "addon_name": "Broseem",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
     "description_confidence": "medium"
   },
   {
@@ -1760,6 +2121,36 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chars",
+    "addon_name": "Chars",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "chatlink",
+    "addon_name": "Chatlink",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
     "description_confidence": "medium"
   },
   {
@@ -1853,6 +2244,36 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "enemybar",
+    "addon_name": "Enemybar",
+    "category": "ui_gear",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "enemybar2",
+    "addon_name": "Enemybar2",
+    "category": "ui_gear",
+    "repos": [
+      "AkadenTK/enemybar2"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 19,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
+    "description_source": "https://github.com/AkadenTK/enemybar2",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "eschachest",
     "addon_name": "Eschachest",
     "category": "general_qol",
@@ -1880,6 +2301,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ffxicaddieprovider",
+    "addon_name": "FFXIcaddieprovider",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
     "description_confidence": "medium"
   },
   {
@@ -1943,6 +2379,51 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "highlight",
+    "addon_name": "Highlight",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "impalert",
+    "addon_name": "Impalert",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "inforeplacer",
+    "addon_name": "Inforeplacer",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "jobchange",
     "addon_name": "Jobchange",
     "category": "general_qol",
@@ -1955,6 +2436,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "lazy",
+    "addon_name": "Lazy",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
     "description_confidence": "medium"
   },
   {
@@ -2093,6 +2589,36 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "nostrum",
+    "addon_name": "Nostrum",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "ohshi",
+    "addon_name": "Ohshi",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "oneoffs",
     "addon_name": "Oneoffs",
     "category": "general_qol",
@@ -2123,6 +2649,21 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "pet_fix",
+    "addon_name": "Pet Fix",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "petparty",
     "addon_name": "Petparty",
     "category": "ui_gear",
@@ -2135,6 +2676,36 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "plasmon",
+    "addon_name": "Plasmon",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "plugin_manager",
+    "addon_name": "Plugin Manager",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
     "description_confidence": "medium"
   },
   {
@@ -2153,6 +2724,21 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "reive",
+    "addon_name": "Reive",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "repeater",
     "addon_name": "Repeater",
     "category": "general_qol",
@@ -2168,6 +2754,21 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "rhombus",
+    "addon_name": "Rhombus",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "roe",
     "addon_name": "Roe",
     "category": "general_qol",
@@ -2180,6 +2781,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "rollbot",
+    "addon_name": "Rollbot",
+    "category": "automation",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
     "description_confidence": "medium"
   },
   {
@@ -2228,6 +2844,36 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "salvage2",
+    "addon_name": "Salvage2",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "satacast",
+    "addon_name": "Satacast",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "schskillchain",
     "addon_name": "Schskillchain",
     "category": "combat_automation",
@@ -2270,6 +2916,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "setbgm",
+    "addon_name": "Setbgm",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
     "description_confidence": "medium"
   },
   {
@@ -2318,19 +2979,18 @@
     "description_confidence": "medium"
   },
   {
-    "addon_key": "smarttarget",
-    "addon_name": "Smarttarget",
-    "category": "combat_automation",
+    "addon_key": "skilluptracker",
+    "addon_name": "Skilluptracker",
+    "category": "general_qol",
     "repos": [
-      "Icydeath/ffxi-addons",
-      "Phayde/Windower-addons"
+      "Lygre/addons"
     ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 8,
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_source": "https://github.com/Lygre/addons",
     "description_confidence": "medium"
   },
   {
@@ -2364,6 +3024,51 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "stna",
+    "addon_name": "Stna",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "stopwatch",
+    "addon_name": "Stopwatch",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "strathelper",
+    "addon_name": "Strathelper",
+    "category": "automation",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "synergy",
     "addon_name": "Synergy",
     "category": "general_qol",
@@ -2379,6 +3084,21 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "taps",
+    "addon_name": "Taps",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "targeter",
     "addon_name": "Targeter",
     "category": "combat_automation",
@@ -2391,6 +3111,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "targetinfo",
+    "addon_name": "Targetinfo",
+    "category": "combat_automation",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
     "description_confidence": "medium"
   },
   {
@@ -2421,6 +3156,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "text",
+    "addon_name": "Text",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
     "description_confidence": "medium"
   },
   {
@@ -2469,6 +3219,21 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "translate",
+    "addon_name": "Translate",
+    "category": "general_qol",
+    "repos": [
+      "Lygre/addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "triggers",
     "addon_name": "Triggers",
     "category": "general_qol",
@@ -2484,6 +3249,21 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "truesight",
+    "addon_name": "Truesight",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "valkyrie",
     "addon_name": "Valkyrie",
     "category": "general_qol",
@@ -2496,6 +3276,21 @@
     "opportunity_score": 3.43,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "visiblefavor",
+    "addon_name": "Visiblefavor",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
     "description_confidence": "medium"
   },
   {
@@ -2619,6 +3414,36 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "xivhotbar",
+    "addon_name": "XIvhotbar",
+    "category": "ui_gear",
+    "repos": [
+      "Akirane/XIVHotbar"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "",
+    "description_source": "",
+    "description_confidence": "low"
+  },
+  {
+    "addon_key": "yush",
+    "addon_name": "Yush",
+    "category": "general_qol",
+    "repos": [
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 1,
+    "best_repo_stars": 17,
+    "freshness_max": 1,
+    "opportunity_score": 3.43,
+    "description": "FFXI Windower 4 Addons",
+    "description_source": "https://github.com/mverteuil/windower4-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "zenimonsnap",
     "addon_name": "Zenimonsnap",
     "category": "general_qol",
@@ -2649,546 +3474,6 @@
     "description_confidence": "medium"
   },
   {
-    "addon_key": "enemybar2",
-    "addon_name": "Enemybar2",
-    "category": "ui_gear",
-    "repos": [
-      "AkadenTK/enemybar2"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 19,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
-    "description_source": "https://github.com/AkadenTK/enemybar2",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ase",
-    "addon_name": "Ase",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autoinvite",
-    "addon_name": "Autoinvite",
-    "category": "automation",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "broseem",
-    "addon_name": "Broseem",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "impalert",
-    "addon_name": "Impalert",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "pet_fix",
-    "addon_name": "Pet Fix",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "plugin_manager",
-    "addon_name": "Plugin Manager",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "rollbot",
-    "addon_name": "Rollbot",
-    "category": "automation",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "skilluptracker",
-    "addon_name": "Skilluptracker",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "stna",
-    "addon_name": "Stna",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "stopwatch",
-    "addon_name": "Stopwatch",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "text",
-    "addon_name": "Text",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "translate",
-    "addon_name": "Translate",
-    "category": "general_qol",
-    "repos": [
-      "Lygre/addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "xivhotbar",
-    "addon_name": "XIvhotbar",
-    "category": "ui_gear",
-    "repos": [
-      "Akirane/XIVHotbar"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "",
-    "description_source": "",
-    "description_confidence": "low"
-  },
-  {
-    "addon_key": "barfiller",
-    "addon_name": "Barfiller",
-    "category": "ui_gear",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chars",
-    "addon_name": "Chars",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "chatlink",
-    "addon_name": "Chatlink",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "enemybar",
-    "addon_name": "Enemybar",
-    "category": "ui_gear",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ffxicaddieprovider",
-    "addon_name": "FFXIcaddieprovider",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "highlight",
-    "addon_name": "Highlight",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "inforeplacer",
-    "addon_name": "Inforeplacer",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "lazy",
-    "addon_name": "Lazy",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "nostrum",
-    "addon_name": "Nostrum",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "ohshi",
-    "addon_name": "Ohshi",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "plasmon",
-    "addon_name": "Plasmon",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "reive",
-    "addon_name": "Reive",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "rhombus",
-    "addon_name": "Rhombus",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "salvage2",
-    "addon_name": "Salvage2",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "satacast",
-    "addon_name": "Satacast",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "setbgm",
-    "addon_name": "Setbgm",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "strathelper",
-    "addon_name": "Strathelper",
-    "category": "automation",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "taps",
-    "addon_name": "Taps",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "targetinfo",
-    "addon_name": "Targetinfo",
-    "category": "combat_automation",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "truesight",
-    "addon_name": "Truesight",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "visiblefavor",
-    "addon_name": "Visiblefavor",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "yush",
-    "addon_name": "Yush",
-    "category": "general_qol",
-    "repos": [
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 17,
-    "freshness_max": 1,
-    "opportunity_score": 3.43,
-    "description": "FFXI Windower 4 Addons",
-    "description_source": "https://github.com/mverteuil/windower4-addons",
-    "description_confidence": "medium"
-  },
-  {
     "addon_key": "skillchain",
     "addon_name": "Skillchain",
     "category": "combat_automation",
@@ -3199,7 +3484,7 @@
     ],
     "repo_count": 3,
     "best_repo_stars": 29,
-    "freshness_max": 5,
+    "freshness_max": 4,
     "opportunity_score": 3.26,
     "description": "Some addons and plugins for FFXI (Ashita)",
     "description_source": "https://github.com/mousseng/xitools",
@@ -3215,55 +3500,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "equipviewer",
-    "addon_name": "Equipviewer",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "partybuffs",
-    "addon_name": "Partybuffs",
-    "category": "automation",
-    "repos": [
-      "Lygre/addons",
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
-    "description_source": "https://github.com/ProjectTako/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "react",
-    "addon_name": "React",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "ProjectTako/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 99,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 2.66,
     "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
     "description_source": "https://github.com/ProjectTako/ffxi-addons",
@@ -3279,7 +3516,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 79,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 2.66,
     "description": "FFXI Windower addons",
     "description_source": "https://github.com/Ivaar/Windower-addons",
@@ -3295,7 +3532,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 79,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 2.66,
     "description": "FFXI Windower addons",
     "description_source": "https://github.com/Ivaar/Windower-addons",
@@ -3311,10 +3548,26 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 79,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 2.66,
     "description": "FFXI Windower addons",
     "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "equipviewer",
+    "addon_name": "Equipviewer",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 99,
+    "freshness_max": 1,
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
     "description_confidence": "medium"
   },
   {
@@ -3327,55 +3580,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "porterpacker",
-    "addon_name": "Porterpacker",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "singer",
-    "addon_name": "Singer",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower addons",
-    "description_source": "https://github.com/Ivaar/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "tradenpc",
-    "addon_name": "Tradenpc",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Ivaar/Windower-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 79,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 2.66,
     "description": "FFXI Windower addons",
     "description_source": "https://github.com/Ivaar/Windower-addons",
@@ -3391,39 +3596,7 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 69,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "quicktrade",
-    "addon_name": "Quicktrade",
-    "category": "ui_gear",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "ValokAsura/WindowerAddons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 2,
-    "opportunity_score": 2.66,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "sendtarget",
-    "addon_name": "Sendtarget",
-    "category": "combat_automation",
-    "repos": [
-      "DiscipleOfEris/Windower4Addons",
-      "Icydeath/ffxi-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 2.66,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -3439,10 +3612,122 @@
     ],
     "repo_count": 2,
     "best_repo_stars": 18,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 2.66,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "partybuffs",
+    "addon_name": "Partybuffs",
+    "category": "automation",
+    "repos": [
+      "Lygre/addons",
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 99,
+    "freshness_max": 1,
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "porterpacker",
+    "addon_name": "Porterpacker",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 1,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "quicktrade",
+    "addon_name": "Quicktrade",
+    "category": "ui_gear",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "ValokAsura/WindowerAddons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "react",
+    "addon_name": "React",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "ProjectTako/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 99,
+    "freshness_max": 1,
+    "opportunity_score": 2.66,
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "description_source": "https://github.com/ProjectTako/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "sendtarget",
+    "addon_name": "Sendtarget",
+    "category": "combat_automation",
+    "repos": [
+      "DiscipleOfEris/Windower4Addons",
+      "Icydeath/ffxi-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "singer",
+    "addon_name": "Singer",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 1,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "tradenpc",
+    "addon_name": "Tradenpc",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Ivaar/Windower-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 79,
+    "freshness_max": 1,
+    "opportunity_score": 2.66,
+    "description": "FFXI Windower addons",
+    "description_source": "https://github.com/Ivaar/Windower-addons",
     "description_confidence": "medium"
   },
   {
@@ -3494,6 +3779,22 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "autosynth",
+    "addon_name": "Autosynth",
+    "category": "automation",
+    "repos": [
+      "Lygre/addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 18,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "autows",
     "addon_name": "Autows",
     "category": "automation",
@@ -3526,230 +3827,6 @@
     "description_confidence": "medium"
   },
   {
-    "addon_key": "clock",
-    "addon_name": "Clock",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dostuff",
-    "addon_name": "Dostuff",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dynamishelper",
-    "addon_name": "Dynamishelper",
-    "category": "automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "fisher",
-    "addon_name": "Fisher",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "lottery",
-    "addon_name": "Lottery",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "macrochanger",
-    "addon_name": "Macrochanger",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "porter",
-    "addon_name": "Porter",
-    "category": "economy_inventory",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "send",
-    "addon_name": "Send",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "silence",
-    "addon_name": "Silence",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "subtarget",
-    "addon_name": "Subtarget",
-    "category": "combat_automation",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "thtracker",
-    "addon_name": "Thtracker",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "timestamp",
-    "addon_name": "Timestamp",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "treasurepool",
-    "addon_name": "Treasurepool",
-    "category": "general_qol",
-    "repos": [
-      "Icydeath/ffxi-addons",
-      "Lygre/addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 69,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Icydeath/ffxi-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "autosynth",
-    "addon_name": "Autosynth",
-    "category": "automation",
-    "repos": [
-      "Lygre/addons",
-      "mverteuil/windower4-addons"
-    ],
-    "repo_count": 2,
-    "best_repo_stars": 18,
-    "freshness_max": 1,
-    "opportunity_score": 2.31,
-    "description": "FFXI Windower Addons",
-    "description_source": "https://github.com/Lygre/addons",
-    "description_confidence": "medium"
-  },
-  {
     "addon_key": "bluguide",
     "addon_name": "Bluguide",
     "category": "travel_navigation",
@@ -3779,6 +3856,22 @@
     "opportunity_score": 2.31,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "clock",
+    "addon_name": "Clock",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
@@ -3827,6 +3920,54 @@
     "opportunity_score": 2.31,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dostuff",
+    "addon_name": "Dostuff",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "dynamishelper",
+    "addon_name": "Dynamishelper",
+    "category": "automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "fisher",
+    "addon_name": "Fisher",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
@@ -3894,6 +4035,38 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "lottery",
+    "addon_name": "Lottery",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "macrochanger",
+    "addon_name": "Macrochanger",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "ohnoyoudont",
     "addon_name": "Ohnoyoudont",
     "category": "general_qol",
@@ -3958,6 +4131,22 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "porter",
+    "addon_name": "Porter",
+    "category": "economy_inventory",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "pricer",
     "addon_name": "Pricer",
     "category": "general_qol",
@@ -4003,6 +4192,38 @@
     "opportunity_score": 2.31,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "send",
+    "addon_name": "Send",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "silence",
+    "addon_name": "Silence",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
@@ -4054,6 +4275,22 @@
     "description_confidence": "medium"
   },
   {
+    "addon_key": "subtarget",
+    "addon_name": "Subtarget",
+    "category": "combat_automation",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
     "addon_key": "synthall",
     "addon_name": "Synthall",
     "category": "general_qol",
@@ -4067,6 +4304,54 @@
     "opportunity_score": 2.31,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Lygre/addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "thtracker",
+    "addon_name": "Thtracker",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "mverteuil/windower4-addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "timestamp",
+    "addon_name": "Timestamp",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
+    "description_confidence": "medium"
+  },
+  {
+    "addon_key": "treasurepool",
+    "addon_name": "Treasurepool",
+    "category": "general_qol",
+    "repos": [
+      "Icydeath/ffxi-addons",
+      "Lygre/addons"
+    ],
+    "repo_count": 2,
+    "best_repo_stars": 69,
+    "freshness_max": 1,
+    "opportunity_score": 2.31,
+    "description": "FFXI Windower Addons",
+    "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "medium"
   },
   {
@@ -4097,7 +4382,7 @@
     ],
     "repo_count": 4,
     "best_repo_stars": 69,
-    "freshness_max": 3,
+    "freshness_max": 1,
     "opportunity_score": 2.27,
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
@@ -4114,7 +4399,7 @@
     ],
     "repo_count": 3,
     "best_repo_stars": 79,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 2.21,
     "description": "FFXI Windower addons",
     "description_source": "https://github.com/Ivaar/Windower-addons",
@@ -4131,7 +4416,7 @@
     ],
     "repo_count": 3,
     "best_repo_stars": 79,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 2.21,
     "description": "FFXI Windower addons",
     "description_source": "https://github.com/Ivaar/Windower-addons",
@@ -4149,7 +4434,7 @@
     ],
     "repo_count": 4,
     "best_repo_stars": 99,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 1.92,
     "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
     "description_source": "https://github.com/ProjectTako/ffxi-addons",
@@ -4167,7 +4452,7 @@
     ],
     "repo_count": 4,
     "best_repo_stars": 79,
-    "freshness_max": 2,
+    "freshness_max": 1,
     "opportunity_score": 1.92,
     "description": "FFXI Windower addons",
     "description_source": "https://github.com/Ivaar/Windower-addons",
@@ -4547,200 +4832,5 @@
     "description": "FFXI Windower Addons",
     "description_source": "https://github.com/Icydeath/ffxi-addons",
     "description_confidence": "low"
-  },
-  {
-    "addon_key": "digskill",
-    "addon_name": "Digskill",
-    "category": "general_qol",
-    "repos": [
-      "Phayde/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 1,
-    "freshness_max": 8,
-    "opportunity_score": 4.2,
-    "description": "A collection of addons for FFXI Windower",
-    "description_source": "https://github.com/Phayde/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "trashit",
-    "addon_name": "Trashit",
-    "category": "general_qol",
-    "repos": [
-      "Phayde/Windower-addons"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 1,
-    "freshness_max": 8,
-    "opportunity_score": 4.2,
-    "description": "A collection of addons for FFXI Windower",
-    "description_source": "https://github.com/Phayde/Windower-addons",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "vanaclock",
-    "addon_name": "Vanaclock",
-    "category": "general_qol",
-    "repos": [
-      "BagTown/vanaclock"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 3,
-    "freshness_max": 25,
-    "opportunity_score": 4.2,
-    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
-    "description_source": "https://github.com/BagTown/vanaclock",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "vanatime",
-    "addon_name": "Vanatime",
-    "category": "general_qol",
-    "repos": [
-      "BagTown/vanaclock"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 3,
-    "freshness_max": 25,
-    "opportunity_score": 4.2,
-    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
-    "description_source": "https://github.com/BagTown/vanaclock",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "fasttarget",
-    "addon_name": "Fasttarget",
-    "category": "general_qol",
-    "repos": [
-      "LordAttilas/FastTarget"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 0,
-    "freshness_max": 6,
-    "opportunity_score": 4.2,
-    "description": "Windower 4 addon for FFXI that allow quicker target change",
-    "description_source": "https://github.com/LordAttilas/FastTarget",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "fancytrusts",
-    "addon_name": "Fancytrusts",
-    "category": "general_qol",
-    "repos": [
-      "ariel-logos/FancyTrusts"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 5,
-    "freshness_max": 14,
-    "opportunity_score": 4.2,
-    "description": "A fancy UI to manage trusts",
-    "description_source": "https://github.com/ariel-logos/FancyTrusts",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "closetcleaner2",
-    "addon_name": "Closetcleaner2",
-    "category": "general_qol",
-    "repos": [
-      "Gol-exe/closetCleaner2"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 0,
-    "freshness_max": 0,
-    "opportunity_score": 4.2,
-    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
-    "description_source": "https://github.com/Gol-exe/closetCleaner2",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "luaparser",
-    "addon_name": "Luaparser",
-    "category": "general_qol",
-    "repos": [
-      "Gol-exe/closetCleaner2"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 0,
-    "freshness_max": 0,
-    "opportunity_score": 4.2,
-    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
-    "description_source": "https://github.com/Gol-exe/closetCleaner2",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "weeklier",
-    "addon_name": "Weeklier",
-    "category": "general_qol",
-    "repos": [
-      "patheed-ffxi/weeklier"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 0,
-    "freshness_max": 5,
-    "opportunity_score": 4.2,
-    "description": "An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.",
-    "description_source": "https://github.com/patheed-ffxi/weeklier",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "mogchat",
-    "addon_name": "Mogchat",
-    "category": "general_qol",
-    "repos": [
-      "glitchv0/mogchat"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 0,
-    "freshness_max": 1,
-    "opportunity_score": 4.2,
-    "description": "AIM/ICQ style FFXI chat addon",
-    "description_source": "https://github.com/glitchv0/mogchat",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "dpsmeter",
-    "addon_name": "Dpsmeter",
-    "category": "general_qol",
-    "repos": [
-      "cybersoulwing/dpsmeter"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 0,
-    "freshness_max": 12,
-    "opportunity_score": 4.2,
-    "description": "FFXI Windower addon",
-    "description_source": "https://github.com/cybersoulwing/dpsmeter",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "automining",
-    "addon_name": "Automining",
-    "category": "general_qol",
-    "repos": [
-      "cybersoulwing/AutoMining"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 0,
-    "freshness_max": 14,
-    "opportunity_score": 4.2,
-    "description": "FFXI Windower addon",
-    "description_source": "https://github.com/cybersoulwing/AutoMining",
-    "description_confidence": "medium"
-  },
-  {
-    "addon_key": "packrat",
-    "addon_name": "Packrat",
-    "category": "general_qol",
-    "repos": [
-      "Mr-Sithel/packrat"
-    ],
-    "repo_count": 1,
-    "best_repo_stars": 1,
-    "freshness_max": 29,
-    "opportunity_score": 4.2,
-    "description": "FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",
-    "description_source": "https://github.com/Mr-Sithel/packrat",
-    "description_confidence": "medium"
   }
 ]

--- a/ffxi_addons_index_raw.json
+++ b/ffxi_addons_index_raw.json
@@ -1,40 +1,176 @@
 [
   {
-    "repo": "ProjectTako/ffxi-addons",
-    "stars": 99,
-    "pushed_at": "2022-11-09T19:45:51Z",
-    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "repo": "AkadenTK/enemybar2",
+    "stars": 19,
+    "pushed_at": "2021-01-30T19:48:45Z",
+    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
     "addon_dirs": [
-      "allseeingeye",
-      "debuff-tracker",
-      "equipviewer",
-      "fastcs",
-      "menus",
-      "partybuffs",
-      "react",
-      "scanzone",
-      "turnaround"
+      "icons"
     ]
   },
   {
-    "repo": "Ivaar/Windower-addons",
-    "stars": 79,
-    "pushed_at": "2023-09-12T03:56:46Z",
-    "description": "FFXI Windower addons",
+    "repo": "AkadenTK/superwarp",
+    "stars": 55,
+    "pushed_at": "2026-03-18T13:55:18Z",
+    "description": "Addon for Windower 4 for FFXI that allows text commands to utilize homepoint, waypoint and survival guide teleport npcs",
     "addon_dirs": [
-      "AuctionHelper",
-      "AutoCOR",
-      "AutoDNC",
-      "AutoGEO",
-      "ChatMan",
-      "PorterPacker",
-      "QuestLog",
-      "SellNPC",
-      "Singer",
-      "Trade",
-      "TradeNPC",
-      "chococard",
-      "htmb"
+      "map"
+    ]
+  },
+  {
+    "repo": "Akirane/XIVHotbar",
+    "stars": 18,
+    "pushed_at": "2020-12-26T23:55:51Z",
+    "description": "",
+    "addon_dirs": [
+      "data",
+      "priv_res",
+      "themes"
+    ]
+  },
+  {
+    "repo": "AliekberFFXI/xivcrossbar",
+    "stars": 17,
+    "pushed_at": "2022-09-15T22:03:23Z",
+    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
+    "addon_dirs": [
+      "libs",
+      "themes",
+      "ui"
+    ]
+  },
+  {
+    "repo": "ariel-logos/FancyTrusts",
+    "stars": 5,
+    "pushed_at": "2026-04-09T10:34:01Z",
+    "description": "A fancy UI to manage trusts",
+    "addon_dirs": [
+      "fancytrusts"
+    ]
+  },
+  {
+    "repo": "BagTown/vanaclock",
+    "stars": 3,
+    "pushed_at": "2026-03-30T01:43:40Z",
+    "description": "Addon for FFXI to implement a vanadiel clock into the game. Including features similar to mithrapride.",
+    "addon_dirs": [
+      "vanaclock",
+      "vanatime"
+    ]
+  },
+  {
+    "repo": "Bryenne-Sylph/tourist",
+    "stars": 3,
+    "pushed_at": "2026-03-15T20:10:54Z",
+    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
+    "addon_dirs": [
+      "tourist"
+    ]
+  },
+  {
+    "repo": "cybersoulwing/AutoMining",
+    "stars": 0,
+    "pushed_at": "2026-04-09T21:16:04Z",
+    "description": "FFXI Windower addon",
+    "addon_dirs": [
+      "automining"
+    ]
+  },
+  {
+    "repo": "cybersoulwing/dpsmeter",
+    "stars": 0,
+    "pushed_at": "2026-04-12T01:09:08Z",
+    "description": "FFXI Windower addon",
+    "addon_dirs": [
+      "dpsmeter"
+    ]
+  },
+  {
+    "repo": "cyritegamestudios/trust",
+    "stars": 49,
+    "pushed_at": "2026-04-23T16:00:56Z",
+    "description": "Windower 4 addon for FFXI to automate your character in battle.",
+    "addon_dirs": [
+      "trust"
+    ]
+  },
+  {
+    "repo": "DiscipleOfEris/Windower4Addons",
+    "stars": 12,
+    "pushed_at": "2024-02-18T18:22:59Z",
+    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
+    "addon_dirs": [
+      "EraDebuffed",
+      "EraDistancePlus",
+      "EraInfoBar",
+      "EraJobChange",
+      "EraMobDrops",
+      "EraMobLevel",
+      "EraPointWatch",
+      "EraScoreboard",
+      "FastFollow",
+      "SendTarget",
+      "assist"
+    ]
+  },
+  {
+    "repo": "ekrividus/autoAssist",
+    "stars": 13,
+    "pushed_at": "2022-11-26T19:34:33Z",
+    "description": "An ffxi windower addon to automatically assist a party member in combat",
+    "addon_dirs": []
+  },
+  {
+    "repo": "flippant/parse",
+    "stars": 15,
+    "pushed_at": "2023-08-12T01:51:20Z",
+    "description": "FFXI Parser Addon for Windower",
+    "addon_dirs": []
+  },
+  {
+    "repo": "glitchv0/mogchat",
+    "stars": 0,
+    "pushed_at": "2026-04-22T15:44:33Z",
+    "description": "AIM/ICQ style FFXI chat addon",
+    "addon_dirs": [
+      "mogchat"
+    ]
+  },
+  {
+    "repo": "Gol-exe/closetCleaner2",
+    "stars": 0,
+    "pushed_at": "2026-04-23T20:03:49Z",
+    "description": "Rework of the ClosetCleaner FFXI Windower Addon",
+    "addon_dirs": [
+      "closetcleaner2",
+      "luaparser"
+    ]
+  },
+  {
+    "repo": "HealsCodes/statustimers",
+    "stars": 15,
+    "pushed_at": "2026-03-01T14:25:55Z",
+    "description": "Statustimers for Ashita v4",
+    "addon_dirs": [
+      "addons"
+    ]
+  },
+  {
+    "repo": "HealsCodes/XIPivot",
+    "stars": 61,
+    "pushed_at": "2026-01-31T13:44:31Z",
+    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
+    "addon_dirs": [
+      "XIPivot"
+    ]
+  },
+  {
+    "repo": "HiPotionQ8/XIchecklist",
+    "stars": 4,
+    "pushed_at": "2026-04-23T09:57:29Z",
+    "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
+    "addon_dirs": [
+      "XIchecklist"
     ]
   },
   {
@@ -186,21 +322,30 @@
     ]
   },
   {
-    "repo": "HealsCodes/XIPivot",
-    "stars": 61,
-    "pushed_at": "2026-01-31T13:44:31Z",
-    "description": "FFXI Ashita & Windower 4 addon to allow dynamic loading of Mods without modification of the original DATs",
+    "repo": "iLVL-Key/FFXI",
+    "stars": 22,
+    "pushed_at": "2026-04-22T15:03:22Z",
+    "description": "Various FFXI projects",
     "addon_dirs": [
-      "XIPivot"
-    ]
-  },
-  {
-    "repo": "AkadenTK/superwarp",
-    "stars": 55,
-    "pushed_at": "2026-03-18T13:55:18Z",
-    "description": "Addon for Windower 4 for FFXI that allows text commands to utilize homepoint, waypoint and survival guide teleport npcs",
-    "addon_dirs": [
-      "map"
+      "Attend",
+      "Bars",
+      "BattlePlan",
+      "Callouts",
+      "Exorcist",
+      "GaolPlan",
+      "Helper",
+      "Informer",
+      "Jingle",
+      "LLMChat",
+      "Leaderboard",
+      "ReadyCheck",
+      "Sweeper",
+      "TaskBar",
+      "VanaFacts",
+      "VanaPad",
+      "Vanity",
+      "ZNMTracker",
+      "emotes"
     ]
   },
   {
@@ -211,22 +356,24 @@
     "addon_dirs": []
   },
   {
-    "repo": "cyritegamestudios/trust",
-    "stars": 49,
-    "pushed_at": "2026-04-23T04:17:39Z",
-    "description": "Windower 4 addon for FFXI to automate your character in battle.",
+    "repo": "Ivaar/Windower-addons",
+    "stars": 79,
+    "pushed_at": "2023-09-12T03:56:46Z",
+    "description": "FFXI Windower addons",
     "addon_dirs": [
-      "trust"
-    ]
-  },
-  {
-    "repo": "Tylas11/XivParty",
-    "stars": 47,
-    "pushed_at": "2026-02-26T20:01:30Z",
-    "description": "A party list addon for Windower 4.",
-    "addon_dirs": [
-      "assets",
-      "layouts"
+      "AuctionHelper",
+      "AutoCOR",
+      "AutoDNC",
+      "AutoGEO",
+      "ChatMan",
+      "PorterPacker",
+      "QuestLog",
+      "SellNPC",
+      "Singer",
+      "Trade",
+      "TradeNPC",
+      "chococard",
+      "htmb"
     ]
   },
   {
@@ -271,31 +418,6 @@
     ]
   },
   {
-    "repo": "mousseng/xitools",
-    "stars": 29,
-    "pushed_at": "2026-03-10T17:38:26Z",
-    "description": "Some addons and plugins for FFXI (Ashita)",
-    "addon_dirs": [
-      "bluspells",
-      "chatty",
-      "colure",
-      "dxui",
-      "imrecast",
-      "libs",
-      "loggers",
-      "minimap-helper",
-      "omen",
-      "rcheck",
-      "relicge",
-      "repl",
-      "skillchain",
-      "strats",
-      "trials",
-      "wheel",
-      "xitools"
-    ]
-  },
-  {
     "repo": "lorand-ffxi/HealBot",
     "stars": 28,
     "pushed_at": "2018-05-22T20:21:49Z",
@@ -305,50 +427,21 @@
     ]
   },
   {
-    "repo": "iLVL-Key/FFXI",
-    "stars": 22,
-    "pushed_at": "2026-04-22T15:03:22Z",
-    "description": "Various FFXI projects",
+    "repo": "LordAttilas/FastTarget",
+    "stars": 0,
+    "pushed_at": "2026-04-18T01:11:58Z",
+    "description": "Windower 4 addon for FFXI that allow quicker target change",
     "addon_dirs": [
-      "Attend",
-      "Bars",
-      "BattlePlan",
-      "Callouts",
-      "Exorcist",
-      "GaolPlan",
-      "Helper",
-      "Informer",
-      "Jingle",
-      "LLMChat",
-      "Leaderboard",
-      "ReadyCheck",
-      "Sweeper",
-      "TaskBar",
-      "VanaFacts",
-      "VanaPad",
-      "Vanity",
-      "ZNMTracker",
-      "emotes"
+      "fasttarget"
     ]
   },
   {
-    "repo": "AkadenTK/enemybar2",
-    "stars": 19,
-    "pushed_at": "2021-01-30T19:48:45Z",
-    "description": "Evolution of the simpler Windower addon that displays a target health bar prominently onscreen",
+    "repo": "Lydya-nick77/readycheck",
+    "stars": 0,
+    "pushed_at": "2026-04-12T14:11:47Z",
+    "description": "FFXI addon to execute a WoW Style Readycheck with the party/alliance",
     "addon_dirs": [
-      "icons"
-    ]
-  },
-  {
-    "repo": "Akirane/XIVHotbar",
-    "stars": 18,
-    "pushed_at": "2020-12-26T23:55:51Z",
-    "description": "",
-    "addon_dirs": [
-      "data",
-      "priv_res",
-      "themes"
+      "readycheck"
     ]
   },
   {
@@ -437,14 +530,37 @@
     ]
   },
   {
-    "repo": "AliekberFFXI/xivcrossbar",
-    "stars": 17,
-    "pushed_at": "2022-09-15T22:03:23Z",
-    "description": "FFXIV-style crossbar for FFXI -- Based on Edeon's XIVHotbar",
+    "repo": "mousseng/xitools",
+    "stars": 29,
+    "pushed_at": "2026-03-10T17:38:26Z",
+    "description": "Some addons and plugins for FFXI (Ashita)",
     "addon_dirs": [
+      "bluspells",
+      "chatty",
+      "colure",
+      "dxui",
+      "imrecast",
       "libs",
-      "themes",
-      "ui"
+      "loggers",
+      "minimap-helper",
+      "omen",
+      "rcheck",
+      "relicge",
+      "repl",
+      "skillchain",
+      "strats",
+      "trials",
+      "wheel",
+      "xitools"
+    ]
+  },
+  {
+    "repo": "Mr-Sithel/packrat",
+    "stars": 1,
+    "pushed_at": "2026-03-25T06:26:58Z",
+    "description": "FFXI addon that tracks items in your inventory, Wardrobe and Wardrobe 2",
+    "addon_dirs": [
+      "packrat"
     ]
   },
   {
@@ -533,95 +649,6 @@
     ]
   },
   {
-    "repo": "ZeromusXYZ/PacketViewerLogViewer",
-    "stars": 17,
-    "pushed_at": "2023-05-18T06:00:22Z",
-    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
-    "addon_dirs": [
-      "Properties",
-      "Res",
-      "data",
-      "forms",
-      "helpers",
-      "redist"
-    ]
-  },
-  {
-    "repo": "flippant/parse",
-    "stars": 15,
-    "pushed_at": "2023-08-12T01:51:20Z",
-    "description": "FFXI Parser Addon for Windower",
-    "addon_dirs": []
-  },
-  {
-    "repo": "HealsCodes/statustimers",
-    "stars": 15,
-    "pushed_at": "2026-03-01T14:25:55Z",
-    "description": "Statustimers for Ashita v4",
-    "addon_dirs": [
-      "addons"
-    ]
-  },
-  {
-    "repo": "ValokAsura/WindowerAddons",
-    "stars": 14,
-    "pushed_at": "2023-02-04T00:29:37Z",
-    "description": "",
-    "addon_dirs": [
-      "Bursting",
-      "CrystalTrader",
-      "MagicAssistant",
-      "QuickTrade 2",
-      "QuickTrade"
-    ]
-  },
-  {
-    "repo": "ekrividus/autoAssist",
-    "stars": 13,
-    "pushed_at": "2022-11-26T19:34:33Z",
-    "description": "An ffxi windower addon to automatically assist a party member in combat",
-    "addon_dirs": []
-  },
-  {
-    "repo": "Technyze/XIVHotbar2",
-    "stars": 13,
-    "pushed_at": "2023-03-12T03:29:46Z",
-    "description": "",
-    "addon_dirs": [
-      "data",
-      "priv_res",
-      "themes"
-    ]
-  },
-  {
-    "repo": "DiscipleOfEris/Windower4Addons",
-    "stars": 12,
-    "pushed_at": "2024-02-18T18:22:59Z",
-    "description": "Addons for FFXI using Windower4 that I (DiscipleOfEris) have written or modified.",
-    "addon_dirs": [
-      "EraDebuffed",
-      "EraDistancePlus",
-      "EraInfoBar",
-      "EraJobChange",
-      "EraMobDrops",
-      "EraMobLevel",
-      "EraPointWatch",
-      "EraScoreboard",
-      "FastFollow",
-      "SendTarget",
-      "assist"
-    ]
-  },
-  {
-    "repo": "HiPotionQ8/XIchecklist",
-    "stars": 4,
-    "pushed_at": "2026-04-23T09:57:29Z",
-    "description": "windower addon for ffxi - Checklist for todo list / mastery rank (quests, key items, warps, monstrosity, fish, roe, moblin maze and other things)",
-    "addon_dirs": [
-      "XIchecklist"
-    ]
-  },
-  {
     "repo": "onimitch/ffxi-zonename",
     "stars": 4,
     "pushed_at": "2026-04-05T14:44:54Z",
@@ -629,12 +656,40 @@
     "addon_dirs": []
   },
   {
-    "repo": "Bryenne-Sylph/tourist",
-    "stars": 3,
-    "pushed_at": "2026-03-15T20:10:54Z",
-    "description": "An addon for FFXI Windower 4 that shows a zone-specific loading screen every time the game loads a new zone. ",
+    "repo": "patheed-ffxi/weeklier",
+    "stars": 0,
+    "pushed_at": "2026-04-18T13:06:18Z",
+    "description": "An Ashita v4addon for HorizonXI that tracks weekly quest completion across all of your characters.",
     "addon_dirs": [
-      "tourist"
+      "weeklier"
+    ]
+  },
+  {
+    "repo": "Phayde/Windower-addons",
+    "stars": 1,
+    "pushed_at": "2026-04-16T02:53:51Z",
+    "description": "A collection of addons for FFXI Windower",
+    "addon_dirs": [
+      "digskill",
+      "smarttarget",
+      "trashit"
+    ]
+  },
+  {
+    "repo": "ProjectTako/ffxi-addons",
+    "stars": 99,
+    "pushed_at": "2022-11-09T19:45:51Z",
+    "description": "Some addons that I've made for FINAL FANTASY XI for both Windower v4 and Ashita v3",
+    "addon_dirs": [
+      "allseeingeye",
+      "debuff-tracker",
+      "equipviewer",
+      "fastcs",
+      "menus",
+      "partybuffs",
+      "react",
+      "scanzone",
+      "turnaround"
     ]
   },
   {
@@ -666,5 +721,53 @@
     "pushed_at": "2026-03-20T01:38:26Z",
     "description": "FFXI - Ashita v4.3 Addon - Zone Line Visualizer",
     "addon_dirs": []
+  },
+  {
+    "repo": "Technyze/XIVHotbar2",
+    "stars": 13,
+    "pushed_at": "2023-03-12T03:29:46Z",
+    "description": "",
+    "addon_dirs": [
+      "data",
+      "priv_res",
+      "themes"
+    ]
+  },
+  {
+    "repo": "Tylas11/XivParty",
+    "stars": 47,
+    "pushed_at": "2026-02-26T20:01:30Z",
+    "description": "A party list addon for Windower 4.",
+    "addon_dirs": [
+      "assets",
+      "layouts"
+    ]
+  },
+  {
+    "repo": "ValokAsura/WindowerAddons",
+    "stars": 14,
+    "pushed_at": "2023-02-04T00:29:37Z",
+    "description": "",
+    "addon_dirs": [
+      "Bursting",
+      "CrystalTrader",
+      "MagicAssistant",
+      "QuickTrade 2",
+      "QuickTrade"
+    ]
+  },
+  {
+    "repo": "ZeromusXYZ/PacketViewerLogViewer",
+    "stars": 17,
+    "pushed_at": "2023-05-18T06:00:22Z",
+    "description": "PacketViewerLogViewer for analyzing FFXI network packets in C-Sharp",
+    "addon_dirs": [
+      "Properties",
+      "Res",
+      "data",
+      "forms",
+      "helpers",
+      "redist"
+    ]
   }
 ]

--- a/ffxi_addons_index_raw.json
+++ b/ffxi_addons_index_raw.json
@@ -95,6 +95,24 @@
     ]
   },
   {
+    "repo": "DiscipleOfEris/MobLevel",
+    "stars": 3,
+    "pushed_at": "2022-08-31T07:34:49Z",
+    "description": "FFXI Windower addon that displays the level of the selected mob in their target box.",
+    "addon_dirs": [
+      "MobLevel"
+    ]
+  },
+  {
+    "repo": "DiscipleOfEris/NpcInteract",
+    "stars": 7,
+    "pushed_at": "2022-01-01T05:09:06Z",
+    "description": "FFXI Windower addon for multiboxers to reduce tedious switching. Allow your alts to copy your main's NPC interactions.",
+    "addon_dirs": [
+      "NpcInteract"
+    ]
+  },
+  {
     "repo": "DiscipleOfEris/Windower4Addons",
     "stars": 12,
     "pushed_at": "2024-02-18T18:22:59Z",
@@ -114,6 +132,15 @@
     ]
   },
   {
+    "repo": "djlabbe/MogMover",
+    "stars": 0,
+    "pushed_at": "2026-03-17T23:11:39Z",
+    "description": "FFXI / Windower Addon - Automated Inventory Management",
+    "addon_dirs": [
+      "MogMover"
+    ]
+  },
+  {
     "repo": "ekrividus/autoAssist",
     "stars": 13,
     "pushed_at": "2022-11-26T19:34:33Z",
@@ -121,11 +148,29 @@
     "addon_dirs": []
   },
   {
+    "repo": "ekrividus/autoMB",
+    "stars": 7,
+    "pushed_at": "2023-12-14T12:37:12Z",
+    "description": "An ffxi windower addon to help with magic bursts",
+    "addon_dirs": [
+      "autoMB"
+    ]
+  },
+  {
     "repo": "flippant/parse",
     "stars": 15,
     "pushed_at": "2023-08-12T01:51:20Z",
     "description": "FFXI Parser Addon for Windower",
     "addon_dirs": []
+  },
+  {
+    "repo": "garyfromwork/Stats",
+    "stars": 1,
+    "pushed_at": "2026-02-04T21:43:50Z",
+    "description": "FFXI Windower Addon for tracking stats in game such as accuracy rate, min/max damage, spell debuff accuracy, ect.",
+    "addon_dirs": [
+      "Stats"
+    ]
   },
   {
     "repo": "glitchv0/mogchat",
@@ -690,6 +735,15 @@
       "react",
       "scanzone",
       "turnaround"
+    ]
+  },
+  {
+    "repo": "rouzazari/magianws",
+    "stars": 0,
+    "pushed_at": "2026-03-17T05:02:37Z",
+    "description": "FFXI Windower addon that assists with Magian Weapon Skill Trials",
+    "addon_dirs": [
+      "magianws"
     ]
   },
   {


### PR DESCRIPTION
## Summary
4h catalog/index/docs sync for FFXI addon landscape.

### Newly added repos
- garyfromwork/Stats
- DiscipleOfEris/NpcInteract
- djlabbe/MogMover
- rouzazari/magianws
- DiscipleOfEris/MobLevel
- ekrividus/autoMB

### Newly added addons
- stats
- npcinteract
- mogmover
- magianws
- moblevel
- automb

### Removed/stale entries
- Repos removed: none
- Addons removed: none

### Confidence notes
- **High confidence**: repo existence + stars + pushed timestamps + descriptions (GitHub API / `gh repo view`).
- **Medium confidence**: addon mapping for these single-purpose repos where repo naming/content aligns to addon identity.
- **Lower confidence**: some repos may contain extra helper modules not separately represented in this pass.

## Scope guardrails followed
- Changes scoped to catalog/index/docs artifacts only.
- No auto-merge performed.

## Validation
- `./scripts/validate.sh` ✅ (no failures)
- JSON parse checks ✅ (`python3 -m json.tool`)
- CSV regenerated from normalized JSON ✅
