### PR TITLE
fix: improve route explain aliases and addon detection

### DIFF
--- a/addons/AddonHealth/addonhealth.lua
+++ b/addons/AddonHealth/addonhealth.lua
@@ -156,11 +156,12 @@ local function get_loaded_addons()
         if type(v) == 'string' then
             names[#names+1] = v
         elseif type(v) == 'table' then
+            if type(k) == 'string' then names[#names+1] = k end
             names[#names+1] = v.name
             names[#names+1] = v.addon
             names[#names+1] = v.short_name
             names[#names+1] = basename(v.path)
-            if v.loaded == false then
+            if v.loaded == false or v.enabled == false then
                 is_loaded = false
             end
         elseif type(k) == 'string' and v then
@@ -169,7 +170,10 @@ local function get_loaded_addons()
 
         for _, name in ipairs(names) do
             if type(name) == 'string' and name ~= '' then
-                loaded[normalize(name)] = is_loaded
+                local key = normalize(name)
+                if is_loaded or loaded[key] == nil then
+                    loaded[key] = is_loaded
+                end
             end
         end
     end

--- a/addons/TravelRouter/travelrouter.lua
+++ b/addons/TravelRouter/travelrouter.lua
@@ -195,12 +195,15 @@ local function print_plan(dest)
 end
 
 local function explain_plan(dest)
-    local key = normalize(dest)
+    local key, alias_used = resolve_destination(dest)
     local candidates = route_candidates(key)
     if not candidates then
         msg(('No route for "%s". Use //troute list or //troute add ...'):format(dest or ''))
+        local suggestions = suggest_destinations(dest, 5)
+        if #suggestions > 0 then msg('Did you mean: ' .. table.concat(suggestions, ', ')) end
         return false
     end
+    if alias_used then msg(('Alias "%s" => "%s"'):format(alias_used, key)) end
 
     local ranked = {}
     for idx, c in ipairs(candidates) do

--- a/tests/test_addonhealth.lua
+++ b/tests/test_addonhealth.lua
@@ -67,4 +67,23 @@ for _, entry in pairs(registered_after) do
     assert(entry.name ~= 'prerender', 'expected prerender to be unregistered on unload')
 end
 
+
+mock.reset()
+mock.set_addon_path('../addons/AddonHealth/')
+mock.install()
+mock.set_addons({
+    TravelRouter = { loaded = false, path = '../addons/TravelRouter/' },
+    SessionConductor = { loaded = true, path = '../addons/SessionConductor/' },
+})
+assert(loadfile('../addons/AddonHealth/addonhealth.lua'))()
+mock.fire_event('addon command', 'check')
+local keyed_log = mock.get_chat_log()
+local saw_travel_alert, saw_dependency_alert = false, false
+for _, entry in ipairs(keyed_log) do
+    if entry.text:find('%[!%] TravelRouter') then saw_travel_alert = true end
+    if entry.text:find('%[alert%] SessionConductor requires TravelRouter') then saw_dependency_alert = true end
+end
+assert(saw_travel_alert, 'expected keyed unloaded addon table to remain unloaded')
+assert(saw_dependency_alert, 'expected dependency alert when keyed dependency is unloaded')
+
 print('test_addonhealth.lua: ok')

--- a/tests/test_travelrouter.lua
+++ b/tests/test_travelrouter.lua
@@ -48,6 +48,36 @@ check('explain produces output', #log > 1)
 check('explain includes candidate scoring header', log[1] and log[1].text:find('Candidate scoring') ~= nil)
 check('explain includes selected marker note', log[#log] and log[#log].text:find('top%-ranked option') ~= nil)
 
+
+-- test explain resolves aliases
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'alias', 'add', 'home', 'jeuno')
+mock.fire_event('addon command', 'explain', 'home')
+log = mock.get_chat_log()
+local saw_alias, saw_scoring = false, false
+for _, entry in ipairs(log) do
+    if entry.text:find('Alias "home" => "jeuno"') then saw_alias = true end
+    if entry.text:find('Candidate scoring for "jeuno"') then saw_scoring = true end
+end
+check('explain resolves alias', saw_alias)
+check('explain scores resolved destination', saw_scoring)
+
+-- test explain suggests close destination on miss
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'explain', 'jeu')
+log = mock.get_chat_log()
+local saw_suggestion = false
+for _, entry in ipairs(log) do
+    if entry.text:find('Did you mean:') and entry.text:find('jeuno') then saw_suggestion = true end
+end
+check('explain suggests close destination', saw_suggestion)
+
 -- test plan with unknown destination
 mock.reset()
 mock.install()


### PR DESCRIPTION
## Summary
- Make `//troute explain <alias>` resolve saved aliases the same way `plan` and `run` already do.
- Add destination suggestions to `explain` misses, matching the existing `plan`/`run` miss UX.
- Improve AddonHealth loaded-addon detection for keyed `windower.get_addons()` tables, and treat `enabled = false` like unloaded.

## Why this adds value
- Users can now inspect route scoring through their own shorthand aliases instead of having to remember canonical destination names.
- Mistyped `explain` commands become actionable instead of dead-end output.
- AddonHealth is less likely to misreport keyed addon entries, especially when Windower/mock data provides the addon name as the table key and marks it disabled/unloaded.

## Validation
- `./scripts/validate.sh`
