### PR TITLE
feat(TravelRouter): add destination search command for faster route discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Suggested smoke test:
 
 ```text
 //troute list
+//troute search je
 //troute plan jeuno
 //conductor ping
 //conductor travel jeuno

--- a/addons/TravelRouter/README.md
+++ b/addons/TravelRouter/README.md
@@ -16,6 +16,7 @@ Content-aware travel routing addon for Windower.
 
 ## Commands
 - `//troute list` — list known destinations
+- `//troute search <text>` — find destinations by prefix/substring (e.g. typo recovery)
 - `//troute plan <destination>` — print best route + scoring rationale
 - `//troute explain <destination>` — show ranked candidate scores and selection reasons
 - `//troute run <destination>` — execute selected route

--- a/addons/TravelRouter/travelrouter.lua
+++ b/addons/TravelRouter/travelrouter.lua
@@ -178,6 +178,15 @@ local function list_destinations()
     msg(('Known destinations (%d): %s'):format(#keys, table.concat(keys, ', ')))
 end
 
+local function search_destinations(input)
+    local suggestions = suggest_destinations(input, 15)
+    if #suggestions == 0 then
+        msg(('No destinations match "%s".'):format(input or ''))
+        return
+    end
+    msg(('Matches for "%s" (%d): %s'):format(input or '', #suggestions, table.concat(suggestions, ', ')))
+end
+
 local function print_plan(dest)
     local resolved, alias_used = resolve_destination(dest)
     local plan, meta = pick_plan(resolved)
@@ -409,10 +418,11 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1])
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: list | plan <dest> | explain <dest> | run <dest> | add <dest> <s1>;... | reset <dest> | alias list|add|remove ... | unlock list|add|remove <k> | save')
+        msg('Commands: list | search <text> | plan <dest> | explain <dest> | run <dest> | add <dest> <s1>;... | reset <dest> | alias list|add|remove ... | unlock list|add|remove <k> | save')
         return
     end
     if cmd == 'list' then list_destinations(); return end
+    if cmd == 'search' then search_destinations(join(args, ' ', 2)); return end
     if cmd == 'plan' then print_plan(join(args, ' ', 2)); return end
     if cmd == 'explain' then explain_plan(join(args, ' ', 2)); return end
     if cmd == 'run' then run_plan(join(args, ' ', 2)); return end

--- a/tests/test_travelrouter.lua
+++ b/tests/test_travelrouter.lua
@@ -27,6 +27,25 @@ local log = mock.get_chat_log()
 check('list produces output', #log > 0)
 check('list mentions destinations', log[1] and log[1].text:find('destinations') ~= nil)
 
+-- test search with partial destination
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'search', 'jeu')
+log = mock.get_chat_log()
+check('search produces output', #log > 0)
+check('search includes matching destination', log[1] and log[1].text:find('jeuno') ~= nil)
+
+-- test search with no matches
+mock.reset()
+mock.install()
+dofile('../addons/TravelRouter/travelrouter.lua')
+
+mock.fire_event('addon command', 'search', 'zzz-nope')
+log = mock.get_chat_log()
+check('search no-match message', #log > 0 and log[1].text:find('No destinations match') ~= nil)
+
 -- test plan with known destination
 mock.reset()
 mock.install()


### PR DESCRIPTION
## Summary
- add `//troute search <text>` command to TravelRouter
- expose destination prefix/substring lookup as an explicit user command
- improve quick discovery and typo recovery without requiring failed `plan`/`run` first
- add unit tests for search match and no-match behavior
- document new command in addon + root README smoke-test flow

## Why this change
Players often remember partial destination names or mistype destination input. Existing fuzzy suggestions only appeared after a failed lookup. This adds a direct, low-risk discovery command with immediate user value.

## Validation
- `./scripts/validate.sh` ✅
  - Passed: JSON catalog validation, rule validation, route validation
  - Warnings: Lua syntax + Lua unit tests skipped because `lua/luac` unavailable in environment
- `./scripts/validate_addons.sh` ✅
  - JSON checks passed
  - Lua checks skipped because `lua/luac` unavailable

## Risk / rollback notes
### Risk
- Low: additive command-path change only (`search`)
- Existing command behavior unchanged (`list`, `plan`, `explain`, `run`, IPC flows unaffected)

### Rollback
- Revert commit `e0a2cff` to fully remove the feature:
  - `git revert e0a2cff`

## Scope
Coherent single-feature PR focused on TravelRouter UX + tests + docs.
