### PR TITLE
feat(AddonHealth): actionable remediation hints + fixes command

### DIFF
--- a/addons/AddonHealth/README.md
+++ b/addons/AddonHealth/README.md
@@ -23,6 +23,7 @@ Unified health dashboard for your Windower addon stack.
 | `//addonhealth export` | Export last report to `data/` directory |
 | `//addonhealth status` | Show current summary |
 | `//addonhealth summary` | Alias for `status` |
+| `//addonhealth fixes` | Show actionable remediation hints from the latest report |
 | `//addonhealth reload` | Reload `data/addons.user.lua` custom monitored addons |
 
 ## Setup
@@ -35,7 +36,7 @@ Unified health dashboard for your Windower addon stack.
 
 ## Output
 
-The check displays severity, known-vs-unknown addon coverage, dependency issues, and file validation results:
+The check displays severity, known-vs-unknown addon coverage, dependency issues, file validation results, and recommended actions:
 
 ```text
 [AddonHealth] --- Health Check @ 14:23:05 ---

--- a/addons/AddonHealth/addonhealth.lua
+++ b/addons/AddonHealth/addonhealth.lua
@@ -1,6 +1,6 @@
 _addon.name = 'AddonHealth'
 _addon.author = 'odin'
-_addon.version = '0.2.0'
+_addon.version = '0.2.1'
 _addon.commands = {'addonhealth', 'ahealth'}
 _addon.description = 'Unified health dashboard for Windower addon stack status and diagnostics.'
 
@@ -283,6 +283,38 @@ local function summarize_severity(report)
     return severity, counts
 end
 
+local function build_recommendations(report)
+    local tips = {}
+
+    for _, entry in ipairs(report.loaded or {}) do
+        if not entry.loaded and entry.critical then
+            tips[#tips+1] = ('Load critical addon: //lua load %s'):format(entry.addon)
+        end
+    end
+
+    for _, issue in ipairs(report.dep_issues or {}) do
+        tips[#tips+1] = ('Load dependency for %s: //lua load %s'):format(issue.addon, issue.missing_dep)
+    end
+
+    for _, issue in ipairs(report.file_issues or {}) do
+        tips[#tips+1] = ('Reinstall or verify file path for %s'):format(issue.label)
+    end
+
+    if #report.unknown_loaded > 0 then
+        tips[#tips+1] = 'Optional: add recurring unknown addons to AddonHealth/data/addons.user.lua for explicit monitoring'
+    end
+
+    local deduped, seen = {}, {}
+    for _, tip in ipairs(tips) do
+        if not seen[tip] then
+            seen[tip] = true
+            deduped[#deduped+1] = tip
+        end
+    end
+
+    return deduped
+end
+
 local function run_diagnostics()
     local player = windower.ffxi.get_player() or {}
     local info = windower.ffxi.get_info() or {}
@@ -300,6 +332,7 @@ local function run_diagnostics()
         unknown_loaded = unknown_loaded,
     }
     report.severity, report.counts = summarize_severity(report)
+    report.recommendations = build_recommendations(report)
     state.lastReport = report
     state.lastCheck = now()
     return report
@@ -331,6 +364,13 @@ local function display_report(report)
         msg('File Issues:')
         for _, issue in ipairs(report.file_issues) do
             msg(('  [%s] %s: %s (%s)'):format(issue.severity, issue.label, issue.status, issue.path))
+        end
+    end
+
+    if report.recommendations and #report.recommendations > 0 then
+        msg('Recommended Actions:')
+        for _, tip in ipairs(report.recommendations) do
+            msg('  - ' .. tip)
         end
     end
 
@@ -378,6 +418,13 @@ local function export_report(report)
         end
     end
 
+    if report.recommendations and #report.recommendations > 0 then
+        f:write('\nRecommended Actions:\n')
+        for _, tip in ipairs(report.recommendations) do
+            f:write(('  - %s\n'):format(tip))
+        end
+    end
+
     f:write(('\nSummary: ok=%d warn=%d alert=%d\n'):format(report.counts.ok or 0, report.counts.warn or 0, report.counts.alert or 0))
     f:close()
     msg('Report exported: ' .. path)
@@ -419,7 +466,7 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1] or '')
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: check | watch on|off [interval] | export | status | summary | reload')
+        msg('Commands: check | watch on|off [interval] | export | status | summary | fixes | reload')
         return
     end
 
@@ -444,6 +491,19 @@ windower.register_event('addon command', function(...)
             #report.unknown_loaded,
             #state.catalogEntries
         ))
+        return
+    end
+
+    if cmd == 'fixes' then
+        local report = state.lastReport or run_diagnostics()
+        if report.recommendations and #report.recommendations > 0 then
+            msg(('Recommended actions (%d):'):format(#report.recommendations))
+            for _, tip in ipairs(report.recommendations) do
+                msg('  - ' .. tip)
+            end
+        else
+            msg('No remediation actions suggested (health is clean).')
+        end
         return
     end
 

--- a/tests/test_addonhealth.lua
+++ b/tests/test_addonhealth.lua
@@ -17,13 +17,15 @@ mock.fire_event('addon command', 'check')
 local log = mock.get_chat_log()
 assert(#log > 0, 'expected health output')
 
-local saw_severity, saw_unknown = false, false
+local saw_severity, saw_unknown, saw_actions = false, false, false
 for _, entry in ipairs(log) do
     if entry.text:find('Severity:') then saw_severity = true end
     if entry.text:find('Unknown Loaded Addons: utility') then saw_unknown = true end
+    if entry.text:find('Recommended Actions:') then saw_actions = true end
 end
 assert(saw_severity, 'expected severity line')
 assert(saw_unknown, 'expected unknown addon coverage line')
+assert(saw_actions, 'expected recommended actions section')
 
 local custom_dir = '../addons/AddonHealth/data'
 os.execute('mkdir -p ' .. custom_dir)
@@ -77,13 +79,18 @@ mock.set_addons({
 })
 assert(loadfile('../addons/AddonHealth/addonhealth.lua'))()
 mock.fire_event('addon command', 'check')
+mock.fire_event('addon command', 'fixes')
 local keyed_log = mock.get_chat_log()
-local saw_travel_alert, saw_dependency_alert = false, false
+local saw_travel_alert, saw_dependency_alert, saw_load_hint, saw_fixes_header = false, false, false, false
 for _, entry in ipairs(keyed_log) do
     if entry.text:find('%[!%] TravelRouter') then saw_travel_alert = true end
     if entry.text:find('%[alert%] SessionConductor requires TravelRouter') then saw_dependency_alert = true end
+    if entry.text:find('Load critical addon: //lua load TravelRouter') then saw_load_hint = true end
+    if entry.text:find('Recommended actions') then saw_fixes_header = true end
 end
 assert(saw_travel_alert, 'expected keyed unloaded addon table to remain unloaded')
 assert(saw_dependency_alert, 'expected dependency alert when keyed dependency is unloaded')
+assert(saw_load_hint, 'expected remediation hint for critical addon load')
+assert(saw_fixes_header, 'expected fixes command output')
 
 print('test_addonhealth.lua: ok')


### PR DESCRIPTION
## Summary
- add recommendation synthesis to AddonHealth reports (missing critical addons, dependency gaps, file issues, unknown addon cataloging)
- render **Recommended Actions** in both in-game check output and exported report files
- add `//addonhealth fixes` command to quickly print remediation hints without full report rerun
- update AddonHealth README command docs
- extend `tests/test_addonhealth.lua` coverage for recommendation output + fixes command

## Why this helps
AddonHealth previously surfaced issues but left players to manually infer the next action. This patch makes results operational by emitting concrete next steps (e.g., `//lua load TravelRouter`).

## Validation
- Ran `./scripts/validate.sh`
  - PASS: catalog JSON validation
  - PASS: rules.default.lua validation
  - PASS: routes.lua validation
  - WARN: `luac` not installed in runner (syntax check skipped)
  - WARN: `lua`/`lua5.1` not installed in runner (unit tests skipped)

## Risk / rollback
### Risk
- Low: additive output only (new recommendations list + new command); no change to core dependency/file detection logic.
- Potential minor UX risk: recommendation verbosity in chat on noisy setups.

### Rollback
- Revert this PR commit (`git revert 2445f34`) to restore previous AddonHealth behavior.
- No data migrations or persistent schema changes involved.
