### PR TITLE
sync: FFXI addon landscape 4h refresh (2026-04-26 08:00 UTC)

### DIFF
--- a/docs/sync-2026-04-26-0800.md
+++ b/docs/sync-2026-04-26-0800.md
@@ -1,0 +1,37 @@
+# 4h Sync Report — 2026-04-26 08:00 UTC
+
+## Scope
+Catalog/index/docs maintenance only:
+- `ffxi_addons_index_raw.json`
+- `ffxi-addon-catalog-normalized.json`
+- `ffxi-addon-catalog-normalized.csv`
+- `docs/sync-2026-04-26-0800.md`
+
+## Repository deltas
+### Added repos
+- None in this sync.
+
+### Updated repo metadata
+- No metadata deltas recorded in this pass.
+
+### Removed repos
+- None in this sync.
+
+## Addon deltas (normalized catalog)
+### Newly added addon entries
+- None in this sync.
+
+### Updated addon mappings
+- No mapping deltas recorded in this pass.
+
+### Removed/stale addon entries
+- None removed in this pass.
+
+## Confidence notes
+- **Medium confidence**: direct search-based discovery run completed with no high-signal new repos detected this cycle.
+- **Low confidence**: GitHub unauthenticated API limits constrained broad metadata refresh coverage for this window; next cycle with higher API budget/token should re-run full metadata sweep.
+
+## Validation
+- Validation script passed: `./scripts/validate.sh`
+- Existing JSON artifacts parse cleanly.
+- CSV remains in sync with normalized JSON from prior successful generation pass.


### PR DESCRIPTION
## Summary
- Added 4h sync report for 2026-04-26 08:00 UTC (`docs/sync-2026-04-26-0800.md`).
- Catalog/index artifacts remained unchanged this cycle (no high-signal repo/addon deltas detected).

## Delta report
### Newly added repos/addons
- None.

### Removed/stale entries
- None.

### Confidence notes
- Medium: search-based discovery run found no strong new candidates this cycle.
- Low: unauthenticated GitHub API rate limits constrained full metadata refresh breadth in this window.

## Validation
- `./scripts/validate.sh` passed (JSON/rules/routes validated; Lua/luac checks skipped because runtime tools are unavailable in this environment).

## Constraints check
- Changes are scoped to docs/catalog/index maintenance for this 4h sync job.
- No auto-merge performed.
