### PR TITLE
chore(sync): 4h catalog refresh (2026-04-27 00:00 UTC)

### DIFF
--- a/docs/sync-2026-04-27-0000.md
+++ b/docs/sync-2026-04-27-0000.md
@@ -1,0 +1,37 @@
+# 4h Sync Report — 2026-04-27 00:00 UTC
+
+## Scope
+Catalog/index/docs maintenance only:
+- `ffxi_addons_index_raw.json`
+- `ffxi-addon-catalog-normalized.json`
+- `ffxi-addon-catalog-normalized.csv`
+- `docs/sync-2026-04-27-0000.md`
+
+## Repository deltas
+### Added repos
+- None in this sync window.
+
+### Updated repo metadata
+- No net metadata deltas detected versus the latest indexed state.
+
+### Removed repos
+- None in this sync.
+
+## Addon deltas (normalized catalog)
+### Newly added addon entries
+- None in this sync window.
+
+### Updated addon mappings
+- No net mapping deltas detected.
+
+### Removed/stale addon entries
+- None removed in this pass.
+
+## Confidence notes
+- **High confidence** that the committed catalog/index artifacts are internally valid and parse cleanly.
+- **Medium confidence** on ecosystem-change detection for this specific 4h window; absence of deltas may reflect either true stability or no newly qualifying repos in the monitored query footprint.
+
+## Validation
+- Validation script passed: `./scripts/validate.sh`
+- JSON artifacts parse cleanly.
+- Catalog/index artifacts remain unchanged this run.


### PR DESCRIPTION
# 4h Sync Report — 2026-04-27 00:00 UTC

## Scope
Catalog/index/docs maintenance only:
- `ffxi_addons_index_raw.json`
- `ffxi-addon-catalog-normalized.json`
- `ffxi-addon-catalog-normalized.csv`
- `docs/sync-2026-04-27-0000.md`

## Repository deltas
### Added repos
- None in this sync window.

### Updated repo metadata
- No net metadata deltas detected versus the latest indexed state.

### Removed repos
- None in this sync.

## Addon deltas (normalized catalog)
### Newly added addon entries
- None in this sync window.

### Updated addon mappings
- No net mapping deltas detected.

### Removed/stale addon entries
- None removed in this pass.

## Confidence notes
- **High confidence** that the committed catalog/index artifacts are internally valid and parse cleanly.
- **Medium confidence** on ecosystem-change detection for this specific 4h window; absence of deltas may reflect either true stability or no newly qualifying repos in the monitored query footprint.

## Validation
- Validation script passed: `./scripts/validate.sh`
- JSON artifacts parse cleanly.
- Catalog/index artifacts remain unchanged this run.
