### PR TITLE
feat(addonhealth): add JSON report export + export directory hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Suggested smoke test:
 //troute plan jeuno
 //conductor ping
 //conductor travel jeuno
+//addonhealth check
+//addonhealth export json
 ```
 
 If you only load `SessionConductor`, the `travel` command will still broadcast, but actual route execution expects `TravelRouter` to be present on the receiving instance.
@@ -143,6 +145,13 @@ See specs:
 - Connectivity check: `//conductor ping`
 - Verify travel orchestration: `//conductor travel jeuno`
 - Review ACK/timeouts: `//conductor status`
+
+### AddonHealth
+- Copy `addons/AddonHealth` into Windower `addons/`
+- Load: `//lua load AddonHealth`
+- Run diagnostics: `//addonhealth check`
+- Export text report: `//addonhealth export`
+- Export JSON report (automation-friendly): `//addonhealth export json`
 
 ### Safety defaults
 - Remote command execution is disabled by default.

--- a/addons/AddonHealth/addonhealth.lua
+++ b/addons/AddonHealth/addonhealth.lua
@@ -1,6 +1,6 @@
 _addon.name = 'AddonHealth'
 _addon.author = 'odin'
-_addon.version = '0.2.1'
+_addon.version = '0.3.0'
 _addon.commands = {'addonhealth', 'ahealth'}
 _addon.description = 'Unified health dashboard for Windower addon stack status and diagnostics.'
 
@@ -58,6 +58,14 @@ local function file_exists(path)
     if not f then return false end
     f:close()
     return true
+end
+
+local function ensure_dir(path)
+    if type(path) ~= 'string' or path == '' then return false end
+    local normalized = path:gsub('[\\/]+$', '')
+    if normalized == '' then return false end
+    local ok = os.execute(('mkdir -p "%s"'):format(normalized))
+    return ok == true or ok == 0
 end
 
 local function addon_base_path()
@@ -378,13 +386,87 @@ local function display_report(report)
     msg('---')
 end
 
-local function export_report(report)
-    local filename = ('addonhealth-report-%s.txt'):format(os.date('%Y%m%d-%H%M%S', report.timestamp))
+local function json_escape(s)
+    return (s:gsub('\\', '\\\\')
+        :gsub('"', '\\"')
+        :gsub('\b', '\\b')
+        :gsub('\f', '\\f')
+        :gsub('\n', '\\n')
+        :gsub('\r', '\\r')
+        :gsub('\t', '\\t'))
+end
+
+local function is_array(tbl)
+    local count = 0
+    for k, _ in pairs(tbl) do
+        if type(k) ~= 'number' then return false end
+        if k < 1 or k % 1 ~= 0 then return false end
+        count = count + 1
+    end
+    return count == #tbl
+end
+
+local function to_json(value)
+    local t = type(value)
+    if t == 'nil' then
+        return 'null'
+    elseif t == 'boolean' then
+        return value and 'true' or 'false'
+    elseif t == 'number' then
+        return tostring(value)
+    elseif t == 'string' then
+        return '"' .. json_escape(value) .. '"'
+    elseif t == 'table' then
+        if is_array(value) then
+            local out = {}
+            for i = 1, #value do
+                out[#out+1] = to_json(value[i])
+            end
+            return '[' .. table.concat(out, ',') .. ']'
+        end
+
+        local keys = {}
+        for k, _ in pairs(value) do
+            if type(k) == 'string' then keys[#keys+1] = k end
+        end
+        table.sort(keys)
+
+        local out = {}
+        for _, key in ipairs(keys) do
+            out[#out+1] = ('"%s":%s'):format(json_escape(key), to_json(value[key]))
+        end
+        return '{' .. table.concat(out, ',') .. '}'
+    end
+
+    return 'null'
+end
+
+local function export_report(report, format)
+    format = normalize(format or 'txt')
+    if format ~= 'txt' and format ~= 'json' then
+        msg('Usage: //addonhealth export [txt|json]')
+        return false
+    end
+
+    if not ensure_dir(REPORT_DIR) then
+        msg('Failed to ensure report directory: ' .. REPORT_DIR)
+        return false
+    end
+
+    local filename = ('addonhealth-report-%s.%s'):format(os.date('%Y%m%d-%H%M%S', report.timestamp), format)
     local path = REPORT_DIR .. filename
     local f = io.open(path, 'w')
     if not f then
         msg('Failed to write report file: ' .. path)
         return false
+    end
+
+    if format == 'json' then
+        f:write(to_json(report))
+        f:write('\n')
+        f:close()
+        msg('Report exported: ' .. path)
+        return true
     end
 
     f:write(('AddonHealth Report - %s\n'):format(os.date('%Y-%m-%d %H:%M:%S', report.timestamp)))
@@ -466,7 +548,7 @@ windower.register_event('addon command', function(...)
     local cmd = normalize(args[1] or '')
 
     if cmd == '' or cmd == 'help' then
-        msg('Commands: check | watch on|off [interval] | export | status | summary | fixes | reload')
+        msg('Commands: check | watch on|off [interval] | export [txt|json] | status | summary | fixes | reload')
         return
     end
 
@@ -477,7 +559,7 @@ windower.register_event('addon command', function(...)
 
     if cmd == 'export' then
         local report = state.lastReport or run_diagnostics()
-        export_report(report)
+        export_report(report, args[2] or 'txt')
         return
     end
 

--- a/tests/test_addonhealth.lua
+++ b/tests/test_addonhealth.lua
@@ -27,6 +27,23 @@ assert(saw_severity, 'expected severity line')
 assert(saw_unknown, 'expected unknown addon coverage line')
 assert(saw_actions, 'expected recommended actions section')
 
+mock.fire_event('addon command', 'export', 'json')
+local exported_json
+for _, entry in ipairs(mock.get_chat_log()) do
+    local path = entry.text:match('Report exported:%s+(.+%.json)$')
+    if path then
+        exported_json = path
+    end
+end
+assert(exported_json, 'expected json export path')
+local exported_handle = io.open(exported_json, 'r')
+assert(exported_handle, 'expected json export file to exist')
+local exported_body = exported_handle:read('*a')
+exported_handle:close()
+assert(exported_body:find('"severity"'), 'expected severity field in json export')
+assert(exported_body:find('"recommendations"'), 'expected recommendations field in json export')
+os.remove(exported_json)
+
 local custom_dir = '../addons/AddonHealth/data'
 os.execute('mkdir -p ' .. custom_dir)
 local custom_file = custom_dir .. '/addons.user.lua'


### PR DESCRIPTION
## Summary
- add `//addonhealth export json` for machine-readable report output
- keep existing text export as default (`//addonhealth export`)
- harden report export reliability by ensuring `AddonHealth/data/` exists before writing
- document AddonHealth export usage in README smoke test + checklist
- extend AddonHealth unit test coverage for JSON export creation/content

## User value
This enables lightweight automation (parsing AddonHealth output by script/tooling) without scraping chat logs, while preserving existing behavior for players who only need text reports.

## Validation
- `./scripts/validate.sh` ✅ (pass: catalog/rules/routes; warnings: `lua/luac` unavailable in CI host)
- `./scripts/validate_addons.sh` ✅ (JSON parse checks passed; Lua syntax step skipped due to missing runtime)

## Risk / rollback notes
- **Risk:** low; change is additive and keeps default export format unchanged.
- **Potential regression surface:** JSON serialization path and report file writing.
- **Rollback:** revert commit `5cdbe39` or disable use of `export json` and continue using `export` (txt).
