### PR TITLE
Docs: final cleanup pass for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,20 @@ Gaps worth building:
 
 ## 🗂️ Repository layout
 
-- `addons/` — complete Windower addons included with this project
+- `addons/` — Windower addons included with this project
 - `specs/` — implementation specs and command surfaces
-- `docs/` — roadmap and reference links used during the landscape scan
-- catalog/index files in the repo root — generated research artifacts for analysis and filtering
+- `docs/` — roadmap, links, and research notes from the landscape scan
+- Root catalog/index files — generated research artifacts for analysis and filtering
+
+## 📚 Documentation quick links
+
+- Main roadmap: `docs/ROADMAP.md`
+- Research/source links: `docs/LINKS.md`
+- Addon specs: `specs/`
+- Addon-level READMEs:
+  - `addons/TravelRouter/README.md`
+  - `addons/SessionConductor/README.md`
+  - `addons/AddonHealth/README.md`
 
 ## ▶️ Using the addons
 
@@ -113,14 +123,15 @@ If you only load `SessionConductor`, the `travel` command will still broadcast, 
 
 - `addons/TravelRouter` — content-aware travel route planner/executor
 - `addons/SessionConductor` — multi-character command coordinator
-  - integrates with TravelRouter via `//conductor travel <destination>`
-  - includes v1.1 event/rule automation engine (`rules.default.lua` + overrides)
-- `addons/AddonHealth` — health/diagnostics dashboard for addon stack, with optional user-extended monitoring catalog via `data/addons.user.lua`
+  - Integrates with TravelRouter via `//conductor travel <destination>`
+  - Includes the v1.1 event/rule automation engine (`rules.default.lua` + overrides)
+- `addons/AddonHealth` — health/diagnostics dashboard for addon stacks, with optional user-extended monitoring via `data/addons.user.lua`
 
 See specs:
 - `specs/travelrouter-v1.0.md`
 - `specs/sessionconductor-v1.0.md`
 - `specs/sessionconductor-v1.1-triggers.md` (event-driven automation model)
+- `specs/addonhealth-v0.1.md`
 
 ## ✅ Production checklist
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,24 +1,24 @@
 # Roadmap
 
-## Phase 1 (done)
+## Phase 1 (completed)
 - [x] First-pass GitHub repo scan
 - [x] Raw index JSON
 - [x] Normalized catalog (JSON/CSV)
-- [x] Initial gap analysis + opportunity shortlist
+- [x] Initial gap analysis and opportunity shortlist
 
-## Phase 2 (next)
-- [ ] Expand repository coverage (50-150 repos)
+## Phase 2 (catalog depth)
+- [ ] Expand repository coverage (50–150 repos)
 - [ ] Improve addon detection beyond top-level directory names
-- [ ] Add compatibility metadata: Windower/Ashita/Era/private server notes
-- [ ] Add confidence score for inferred categories
+- [ ] Add compatibility metadata (Windower/Ashita/Era/private-server notes)
+- [ ] Add confidence scoring for inferred categories
 
-## Phase 3 (productize)
+## Phase 3 (productization)
 - [ ] Publish static searchable site
 - [ ] Add tags and faceted filters (category, activity, popularity)
-- [ ] Add "starter addon ideas" page with implementation complexity
-- [ ] Ship first addon concept spec (`AddonHealth` or `OnboardingPilot`)
+- [ ] Add a "starter addon ideas" page with implementation complexity
+- [x] Ship first addon concepts and specs (`TravelRouter`, `SessionConductor`, `AddonHealth`)
 
 ## Contribution guidelines (draft)
-- Use PRs for repo additions/corrections
+- Use pull requests for repo additions and corrections
 - Include source links for metadata edits
 - Prefer reproducible scripts over manual edits

--- a/prototypes/addonhealth/README.md
+++ b/prototypes/addonhealth/README.md
@@ -1,6 +1,6 @@
 # AddonHealth Prototype Scaffold
 
-This folder is a placeholder scaffold for the first implementation pass.
+This folder preserves an early scaffold from the first implementation pass.
 
 Planned structure:
 
@@ -10,4 +10,4 @@ Planned structure:
 - `render.lua` — HUD text rendering
 - `data/` — local snapshots/reports
 
-Status: scaffold only (no runtime code committed yet).
+Status: historical scaffold only. Active runtime implementation lives in `addons/AddonHealth/`.


### PR DESCRIPTION
## Summary

Final docs-focused cleanup pass to improve clarity and consistency across contributor-facing markdown.

### Updated files

- **README.md**
  - Tightened wording and normalized tone.
  - Added a **Documentation quick links** section.
  - Updated addon/spec references (including `specs/addonhealth-v0.1.md`).
  - Normalized capitalization/phrasing in addon descriptions.

- **docs/ROADMAP.md**
  - Removed stale wording and aligned status with current repo state.
  - Marked shipped addon concepts/specs as complete.
  - Improved heading/list consistency.

- **prototypes/addonhealth/README.md**
  - Clarified that it is a historical scaffold.
  - Added a pointer to active implementation in `addons/AddonHealth/`.

## Validation

Ran:

```bash
./scripts/validate_addons.sh
```

Result:

- JSON parse checks passed.
- Lua syntax checks were skipped because `luac`/`lua` are not installed in this environment.
